### PR TITLE
Inverted positions and fixed reported history

### DIFF
--- a/custom_components/bosch_shc/cover.py
+++ b/custom_components/bosch_shc/cover.py
@@ -49,7 +49,7 @@ class ShutterControlCover(SHCEntity, CoverEntity):
     @property
     def current_cover_position(self):
         """Return the current cover position."""
-        return self._device.level * 100.0
+        return (1.0 - self._device.level) * 100.0
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
@@ -61,15 +61,15 @@ class ShutterControlCover(SHCEntity, CoverEntity):
         if self.current_cover_position is None:
             return None
         if self.current_cover_position == 0.0:
-            return True
-        return False
+            return False
+        return True
 
     @property
     def is_opening(self):
         """Return if the cover is opening or not."""
         return (
             self._device.operation_state
-            == SHCShutterControl.ShutterControlService.State.OPENING
+            == SHCShutterControl.ShutterControlService.State.CLOSING
         )
 
     @property
@@ -77,7 +77,7 @@ class ShutterControlCover(SHCEntity, CoverEntity):
         """Return if the cover is closing or not."""
         return (
             self._device.operation_state
-            == SHCShutterControl.ShutterControlService.State.CLOSING
+            == SHCShutterControl.ShutterControlService.State.OPENING
         )
 
     def open_cover(self, **kwargs):
@@ -93,4 +93,4 @@ class ShutterControlCover(SHCEntity, CoverEntity):
         if ATTR_POSITION in kwargs:
             position = float(kwargs[ATTR_POSITION])
             position = min(100, max(0, position))
-            self._device.level = position / 100.0
+            self._device.level = (100.0 - position) / 100.0


### PR DESCRIPTION
The positions as well as the reported histories of the covers were inverted/wrong, which is fixed now. I know it seems counterintuitive in the code, but the reporting within Home Assistant's history is now working correctly and the position usage is in line with the Bosch Smart Home App. Google Assistant works correctly too now.

In addition, any position that is not fully open (0 now being open and 100 being closed) is now getting reported as closed. This makes more sense in my opinion, as shutters are mostly fully open when considered open and often only closed halfway or so, while already being considered (partly) closed.

I was unsure about the underlying architecture's usage of float and int, so I tried to adapt to the style and used what seemed safest. I hope this is correct, if not feel free to change it.

This was briefly tested and worked as expected without any problems at all.