### PR TITLE
Fix automations not working due to removed TriggerActionType in 2025.1.0

### DIFF
--- a/custom_components/bosch_shc/device_trigger.py
+++ b/custom_components/bosch_shc/device_trigger.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 
 import voluptuous as vol
 from boschshcpy import SHCDevice, SHCSession
-from homeassistant.components.automation import TriggerActionType
+from homeassistant.helpers.trigger import TriggerActionType
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,


### PR DESCRIPTION
Was moved to helpers.trigger with https://github.com/home-assistant/core/commit/c93d9d9a90227fbffd2e36c04710183c8cca999d

Was deprecated with https://github.com/home-assistant/core/commit/db985925c47697f391253d31b9ecfa363a1f9f6d

Was removed with https://github.com/home-assistant/core/commit/fb152c7d220ec9c7227e9ea495699db1937aee8f

Fixes #219