### PR TITLE
Add cooling mode (HVACMode.COOL) support to climate integration

### DIFF
--- a/custom_components/bosch_shc/climate.py
+++ b/custom_components/bosch_shc/climate.py
@@ -105,6 +105,9 @@ class ClimateControl(SHCEntity, ClimateEntity):
         if self._device.summer_mode:
             return HVACMode.OFF
 
+        if self._device.supports_cooling and self._device.cooling_mode:
+            return HVACMode.COOL
+
         if (
             self._device.operation_mode
             == SHCClimateControl.RoomClimateControlService.OperationMode.AUTOMATIC
@@ -116,7 +119,10 @@ class ClimateControl(SHCEntity, ClimateEntity):
     @property
     def hvac_modes(self):
         """Return available hvac modes."""
-        return [HVACMode.AUTO, HVACMode.HEAT, HVACMode.OFF]
+        modes = [HVACMode.AUTO, HVACMode.HEAT, HVACMode.OFF]
+        if self._device.supports_cooling:
+            modes.append(HVACMode.COOL)
+        return modes
 
     # @property
     # def hvac_action(self):
@@ -191,6 +197,10 @@ class ClimateControl(SHCEntity, ClimateEntity):
             await self.hass.async_add_executor_job(
                 setattr, self._device, "summer_mode", False
             )
+            if self._device.supports_cooling:
+                await self.hass.async_add_executor_job(
+                    setattr, self._device, "cooling_mode", False
+                )
             await self.hass.async_add_executor_job(
                 setattr,
                 self._device,
@@ -201,13 +211,28 @@ class ClimateControl(SHCEntity, ClimateEntity):
             await self.hass.async_add_executor_job(
                 setattr, self._device, "summer_mode", False
             )
+            if self._device.supports_cooling:
+                await self.hass.async_add_executor_job(
+                    setattr, self._device, "cooling_mode", False
+                )
             await self.hass.async_add_executor_job(
                 setattr,
                 self._device,
                 "operation_mode",
                 SHCClimateControl.RoomClimateControlService.OperationMode.MANUAL,
             )
+        if hvac_mode == HVACMode.COOL:
+            await self.hass.async_add_executor_job(
+                setattr, self._device, "summer_mode", False
+            )
+            await self.hass.async_add_executor_job(
+                setattr, self._device, "cooling_mode", True
+            )
         if hvac_mode == HVACMode.OFF:
+            if self._device.supports_cooling:
+                await self.hass.async_add_executor_job(
+                    setattr, self._device, "cooling_mode", False
+                )
             await self.hass.async_add_executor_job(
                 setattr, self._device, "summer_mode", True
             )


### PR DESCRIPTION
Exposes `HVACMode.COOL` as a selectable mode in Home Assistant for Bosch room thermostats that support cooling.

### Changes
- **Available Modes**: Conditionally appends `HVACMode.COOL` to `hvac_modes` if the thermostat reports `supports_cooling`.
- **State Mapping**: Returns `HVACMode.COOL` when `cooling_mode` is active on the device.
- **Control Logic**: Configures `async_set_hvac_mode` to activate `cooling_mode=True` (and clear `summer_mode`) when set to `COOL`, and ensures cooling is disabled when switching to other modes.

### Testing
- Tested and verified working successfully with my **Bosch Raumthermostat Fußbodenheizung 230V**.

### Dependencies
- **Requires API changes in `boschshcpy`**: Linked here: https://github.com/tschamm/boschshcpy/pull/62
