### PR TITLE
0.4.105: collected fixes + Heating Circuit + cooling

### DIFF
--- a/custom_components/bosch_shc/__init__.py
+++ b/custom_components/bosch_shc/__init__.py
@@ -267,7 +267,9 @@ def register_services(hass, entry):
                 if isinstance(session, SHCSession):
                     for scenario in session.scenarios:
                         if scenario.name == name:
-                            hass.async_add_executor_job(scenario.trigger)
+                            # await so a failed trigger surfaces instead of being
+                            # silently discarded (async migration, phase 0).
+                            await hass.async_add_executor_job(scenario.trigger)
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/bosch_shc/alarm_control_panel.py
+++ b/custom_components/bosch_shc/alarm_control_panel.py
@@ -99,6 +99,8 @@ class IntrusionSystemAlarmControlPanel(AlarmControlPanelEntity):
         """Return the state of the device."""
         if self._device.alarm_state == SHCIntrusionSystem.AlarmState.ALARM_ON:
             return AlarmControlPanelState.TRIGGERED
+        if self._device.alarm_state == SHCIntrusionSystem.AlarmState.ALARM_MUTED:
+            return AlarmControlPanelState.TRIGGERED
         if self._device.alarm_state == SHCIntrusionSystem.AlarmState.PRE_ALARM:
             return AlarmControlPanelState.PENDING
 
@@ -132,8 +134,8 @@ class IntrusionSystemAlarmControlPanel(AlarmControlPanelEntity):
         """Return the list of supported features."""
         return (
             AlarmControlPanelEntityFeature.ARM_AWAY
-            + AlarmControlPanelEntityFeature.ARM_HOME
-            + AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
+            | AlarmControlPanelEntityFeature.ARM_HOME
+            | AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
         )
 
     @property

--- a/custom_components/bosch_shc/binary_sensor.py
+++ b/custom_components/bosch_shc/binary_sensor.py
@@ -363,7 +363,15 @@ class SmokeDetectorSensor(SHCEntity, BinarySensorEntity):
     @property
     def is_on(self):
         """Return the state of the sensor."""
-        return self._device.alarmstate != SHCSmokeDetector.AlarmService.State.IDLE_OFF
+        # Only PRIMARY_ALARM and SECONDARY_ALARM are smoke-related states.
+        # INTRUSION_ALARM is set by the IDS (intrusion detection system) on all
+        # smoke detectors when a surveillance alarm fires — it must NOT be treated
+        # as a smoke event, or every detector reports smoke whenever any burglar
+        # alarm triggers (issue #191).
+        return self._device.alarmstate in (
+            SHCSmokeDetector.AlarmService.State.PRIMARY_ALARM,
+            SHCSmokeDetector.AlarmService.State.SECONDARY_ALARM,
+        )
 
     @property
     def icon(self):

--- a/custom_components/bosch_shc/climate.py
+++ b/custom_components/bosch_shc/climate.py
@@ -1,6 +1,7 @@
 """Platform for climate integration."""
 
 from boschshcpy import SHCClimateControl, SHCSession
+from boschshcpy.exceptions import JSONRPCError, SHCException
 from enum import IntFlag
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
@@ -166,13 +167,28 @@ class ClimateControl(SHCEntity, ClimateEntity):
             )
             return
 
-        if self.min_temp <= temperature <= self.max_temp:
-            await self.hass.async_add_executor_job(
-                setattr,
-                self._device,
-                "setpoint_temperature",
-                float(round(temperature * 2.0) / 2.0),
+        if self.preset_mode == PRESET_BOOST:
+            LOGGER.warning(
+                "Cannot set temperature on device %s while in BOOST mode "
+                "(SHC rejects setpoint writes in this state).",
+                self.device_name,
             )
+            return
+
+        if self.min_temp <= temperature <= self.max_temp:
+            try:
+                await self.hass.async_add_executor_job(
+                    setattr,
+                    self._device,
+                    "setpoint_temperature",
+                    float(round(temperature * 2.0) / 2.0),
+                )
+            except (JSONRPCError, SHCException) as err:
+                LOGGER.warning(
+                    "Failed to set temperature on device %s: %s",
+                    self.device_name,
+                    err,
+                )
 
     async def async_set_hvac_mode(self, hvac_mode: str):
         """Set hvac mode."""

--- a/custom_components/bosch_shc/climate.py
+++ b/custom_components/bosch_shc/climate.py
@@ -1,11 +1,11 @@
 """Platform for climate integration."""
 
-from boschshcpy import SHCClimateControl, SHCSession
+from boschshcpy import SHCClimateControl, SHCHeatingCircuit, SHCSession
 from boschshcpy.exceptions import JSONRPCError, SHCException
-from enum import IntFlag
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     ATTR_HVAC_MODE,
+    HVACAction,
     HVACMode,
     ClimateEntityFeature,
     PRESET_BOOST,
@@ -30,6 +30,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 device=climate,
                 entry_id=config_entry.entry_id,
                 name=f"Room Climate {session.room(room_id).name}",
+            )
+        )
+
+    for heating_circuit in session.device_helper.heating_circuits:
+        entities.append(
+            HeatingCircuit(
+                device=heating_circuit,
+                entry_id=config_entry.entry_id,
+                name=heating_circuit.name,
             )
         )
 
@@ -100,6 +109,9 @@ class ClimateControl(SHCEntity, ClimateEntity):
         if self._device.summer_mode:
             return HVACMode.OFF
 
+        if self._device.supports_cooling and self._device.cooling_mode:
+            return HVACMode.COOL
+
         if (
             self._device.operation_mode
             == SHCClimateControl.RoomClimateControlService.OperationMode.AUTOMATIC
@@ -111,7 +123,10 @@ class ClimateControl(SHCEntity, ClimateEntity):
     @property
     def hvac_modes(self):
         """Return available hvac modes."""
-        return [HVACMode.AUTO, HVACMode.HEAT, HVACMode.OFF]
+        modes = [HVACMode.AUTO, HVACMode.HEAT, HVACMode.OFF]
+        if self._device.supports_cooling:
+            modes.append(HVACMode.COOL)
+        return modes
 
     # @property
     # def hvac_action(self):
@@ -201,6 +216,10 @@ class ClimateControl(SHCEntity, ClimateEntity):
             await self.hass.async_add_executor_job(
                 setattr, self._device, "summer_mode", False
             )
+            if self._device.supports_cooling:
+                await self.hass.async_add_executor_job(
+                    setattr, self._device, "cooling_mode", False
+                )
             await self.hass.async_add_executor_job(
                 setattr,
                 self._device,
@@ -211,13 +230,28 @@ class ClimateControl(SHCEntity, ClimateEntity):
             await self.hass.async_add_executor_job(
                 setattr, self._device, "summer_mode", False
             )
+            if self._device.supports_cooling:
+                await self.hass.async_add_executor_job(
+                    setattr, self._device, "cooling_mode", False
+                )
             await self.hass.async_add_executor_job(
                 setattr,
                 self._device,
                 "operation_mode",
                 SHCClimateControl.RoomClimateControlService.OperationMode.MANUAL,
             )
+        if hvac_mode == HVACMode.COOL:
+            await self.hass.async_add_executor_job(
+                setattr, self._device, "summer_mode", False
+            )
+            await self.hass.async_add_executor_job(
+                setattr, self._device, "cooling_mode", True
+            )
         if hvac_mode == HVACMode.OFF:
+            if self._device.supports_cooling:
+                await self.hass.async_add_executor_job(
+                    setattr, self._device, "cooling_mode", False
+                )
             await self.hass.async_add_executor_job(
                 setattr, self._device, "summer_mode", True
             )
@@ -271,3 +305,82 @@ class ClimateControl(SHCEntity, ClimateEntity):
         """Turn the climate device off."""
         if self.hvac_mode != HVACMode.OFF:
             await self.async_set_hvac_mode(HVACMode.OFF)
+
+
+class HeatingCircuit(SHCEntity, ClimateEntity):
+    """Representation of a SHC heating circuit.
+
+    The HeatingCircuit service exposes a setpoint temperature and an operation
+    mode (AUTOMATIC/MANUAL); there is no measured room temperature and the on
+    state is read-only, so this maps to a HEAT/AUTO climate entity with a
+    heating/idle action and no OFF mode.
+    """
+
+    _attr_target_temperature_step = 0.5
+    _enable_turn_on_off_backwards_compatibility = False
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_max_temp = 30.0
+    _attr_min_temp = 5.0
+    _attr_hvac_modes = [HVACMode.AUTO, HVACMode.HEAT]
+    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+
+    def __init__(
+        self,
+        device: SHCHeatingCircuit,
+        name: str,
+        entry_id: str,
+    ) -> None:
+        """Initialize the SHC heating circuit."""
+        super().__init__(device=device, entry_id=entry_id)
+        self._attr_unique_id = f"{device.root_device_id}_{device.id}"
+
+    @property
+    def current_temperature(self):
+        """Heating circuits expose no measured temperature."""
+        return None
+
+    @property
+    def target_temperature(self):
+        """Return the setpoint temperature."""
+        return self._device.setpoint_temperature
+
+    @property
+    def hvac_mode(self):
+        """Return the hvac mode derived from the operation mode."""
+        if (
+            self._device.operation_mode
+            == SHCHeatingCircuit.HeatingCircuitService.OperationMode.AUTOMATIC
+        ):
+            return HVACMode.AUTO
+        return HVACMode.HEAT
+
+    @property
+    def hvac_action(self):
+        """Return whether the circuit is currently heating."""
+        return HVACAction.HEATING if self._device.on else HVACAction.IDLE
+
+    async def async_set_temperature(self, **kwargs):
+        """Set a new setpoint temperature."""
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        if temperature is None:
+            return
+        if self.min_temp <= temperature <= self.max_temp:
+            await self.hass.async_add_executor_job(
+                setattr,
+                self._device,
+                "setpoint_temperature",
+                float(round(temperature * 2.0) / 2.0),
+            )
+
+    async def async_set_hvac_mode(self, hvac_mode: str):
+        """Set the operation mode."""
+        if hvac_mode not in self.hvac_modes:
+            return
+        mode = (
+            SHCHeatingCircuit.HeatingCircuitService.OperationMode.AUTOMATIC
+            if hvac_mode == HVACMode.AUTO
+            else SHCHeatingCircuit.HeatingCircuitService.OperationMode.MANUAL
+        )
+        await self.hass.async_add_executor_job(
+            setattr, self._device, "operation_mode", mode
+        )

--- a/custom_components/bosch_shc/cover.py
+++ b/custom_components/bosch_shc/cover.py
@@ -60,7 +60,22 @@ async def async_setup_entry(
 
 
 class ShutterControlCover(SHCEntity, CoverEntity):
-    """Representation of a SHC shutter control device."""
+    """Representation of a SHC shutter control device.
+
+    Issue #183 — state stops refreshing after hours:
+    The root cause lives in boschshcpy's long-polling loop
+    (session.py::_long_poll).  When the SHC invalidates the poll-ID
+    (JSONRPCError -32001), the library resets _poll_id to None and
+    re-subscribes on the next iteration, but does NOT push a fresh state
+    snapshot to the registered _callbacks.  Any STOPPED/level changes that
+    occurred during the gap are therefore never delivered to this entity.
+    Fixing this properly requires boschshcpy to call short_poll() on each
+    service after re-subscription, which is outside the scope of this
+    integration.  A workaround would be to enable should_poll=True here and
+    implement async_update() calling service.short_poll(), but that doubles
+    API traffic during normal operation.  Tracked upstream; do not attempt
+    to paper over it by adding polling here without a companion boschshcpy fix.
+    """
 
     _attr_supported_features = (
         CoverEntityFeature.OPEN

--- a/custom_components/bosch_shc/event.py
+++ b/custom_components/bosch_shc/event.py
@@ -110,6 +110,10 @@ class UniversalSwitchEvent(SHCEntity, EventEntity):
 
         self._device = device
         self._key_id = key_id
+        # Guard against phantom events: track the last event timestamp we fired
+        # on so a battery-level long-poll that re-delivers a stale Keypad state
+        # (same keyName, same eventTimestamp) does not trigger a duplicate event.
+        self._last_fired_timestamp: int = -1
 
         self.entity_id = ENTITY_ID_FORMAT.format(
             f"{slugify(self._device.name)}_button_{key_id.casefold()}"
@@ -126,22 +130,41 @@ class UniversalSwitchEvent(SHCEntity, EventEntity):
                 service.register_event(self._key_id, self._event_callback)
 
     def _event_callback(self) -> None:
-        event_type = self._device.eventtype.name
+        # Issue #192: The SHC sometimes delivers a Keypad service update that
+        # piggybacks on a battery-level change, replaying the last stale keyName
+        # and eventTimestamp without a new keypress having occurred.  Guard:
+        # (1) eventtype must be a genuine button press, never None or a
+        #     SWITCH_ON/SWITCH_OFF motor event; (2) eventtimestamp must have
+        #     advanced since the last event we actually fired.
+        event_type_raw = self._device.eventtype
+        if event_type_raw is None:
+            return
+        event_type = event_type_raw.name
+        if event_type not in ["PRESS_SHORT", "PRESS_LONG", "PRESS_LONG_RELEASED"]:
+            return
+        current_ts = self._device.eventtimestamp
+        if current_ts == self._last_fired_timestamp:
+            LOGGER.debug(
+                "Skipping duplicate Keypad event for %s (ts=%s unchanged)",
+                self.entity_id,
+                current_ts,
+            )
+            return
+        self._last_fired_timestamp = current_ts
         event_attributes = {
             ATTR_DEVICE_ID: self.device_id,
             ATTR_EVENT_TYPE: event_type,
             ATTR_ID: self._device.id,
             ATTR_NAME: self._device.name,
-            ATTR_LAST_TIME_TRIGGERED: self._device.eventtimestamp,
+            ATTR_LAST_TIME_TRIGGERED: current_ts,
         }
-        if event_type in ["PRESS_SHORT", "PRESS_LONG", "PRESS_LONG_RELEASED"]:
-            try:
-                self._trigger_event(event_type, event_attributes)
-            except ValueError:
-                LOGGER.warning(
-                    "Invalid event type %s for %s", event_type, self.entity_id
-                )
-                return
+        try:
+            self._trigger_event(event_type, event_attributes)
+        except ValueError:
+            LOGGER.warning(
+                "Invalid event type %s for %s", event_type, self.entity_id
+            )
+            return
         self.schedule_update_ha_state()
 
 

--- a/custom_components/bosch_shc/light.py
+++ b/custom_components/bosch_shc/light.py
@@ -48,7 +48,10 @@ class LightSwitch(SHCEntity, LightEntity):
             self._attr_color_mode = ColorMode.HS
         if self._device.supports_color_temp:
             self._attr_supported_color_modes.add(ColorMode.COLOR_TEMP)
-            self._attr_color_mode = ColorMode.COLOR_TEMP
+            # Only set COLOR_TEMP as default when HS is NOT also supported;
+            # when both are present, HS takes priority (set above).
+            if not self._device.supports_color_hsb:
+                self._attr_color_mode = ColorMode.COLOR_TEMP
         if self._device.supports_color_hsb or self._device.supports_color_temp:
             self._attr_min_color_temp_kelvin = (
                 color_util.color_temperature_mired_to_kelvin(
@@ -79,9 +82,12 @@ class LightSwitch(SHCEntity, LightEntity):
         return self._device.binarystate
 
     @property
-    def brightness(self) -> int:
+    def brightness(self) -> int | None:
         """Return the brightness of this light between 0..255."""
-        return round(self._device.brightness * 255 / 100)
+        raw = self._device.brightness
+        if raw is None:
+            return None
+        return round(raw * 255 / 100)
 
     @property
     def hs_color(self):
@@ -102,6 +108,9 @@ class LightSwitch(SHCEntity, LightEntity):
         brightness = kwargs.get(ATTR_BRIGHTNESS)
 
         if brightness is not None and self._device.supports_brightness:
+            # Bosch API does not accept brightness=0; HA uses brightness=0 to
+            # mean "off", which is handled via binarystate. Clamp to 1 so that
+            # a near-zero HA value (e.g. 1/255) never silently turns off.
             self._device.brightness = max(round(brightness * 100 / 255), 1)
 
         if color_temp_kelvin is not None and self._device.supports_color_temp:

--- a/custom_components/bosch_shc/manifest.json
+++ b/custom_components/bosch_shc/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://github.com/tschamm/boschshc-hass/blob/master/README.md",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/tschamm/boschshc-hass/issues",
-  "requirements": ["boschshcpy==0.2.111"],
-  "version": "0.4.104",
+  "requirements": ["boschshcpy==0.2.113"],
+  "version": "0.4.105",
   "zeroconf": [{ "type": "_http._tcp.local.", "name": "bosch shc*" }]
 }

--- a/custom_components/bosch_shc/number.py
+++ b/custom_components/bosch_shc/number.py
@@ -1,4 +1,4 @@
-"""Platform for switch integration."""
+"""Platform for number integration."""
 
 from __future__ import annotations
 
@@ -69,8 +69,9 @@ class SHCNumber(SHCEntity, NumberEntity):
         self._device: SHCThermostat = device
 
     def set_native_value(self, value: float) -> None:
-        """Update the current value."""
-        self._device.offset = value
+        """Update the current value, clamped to [native_min_value, native_max_value]."""
+        clamped = max(self.native_min_value, min(self.native_max_value, value))
+        self._device.offset = clamped
 
     @property
     def native_value(self) -> float:

--- a/custom_components/bosch_shc/switch.py
+++ b/custom_components/bosch_shc/switch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 from boschshcpy import (
@@ -37,6 +38,8 @@ from homeassistant.helpers.typing import StateType
 
 from .const import DATA_SESSION, DOMAIN, DATA_SHC
 from .entity import SHCEntity, async_migrate_to_new_unique_id
+
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -556,12 +559,34 @@ class SHCSwitch(SHCEntity, SwitchEntity):
             return None
 
     def turn_on(self, **kwargs) -> None:
-        """Turn the switch on."""
-        setattr(self._device, self.entity_description.on_key, True)
+        """Turn the switch on.
+
+        Guard against AttributeError: some devices (e.g. MicromoduleRelay with
+        no connected load, Camera360 with no PrivacyMode service) expose a
+        property whose underlying service is None.  Swallow and log instead of
+        crash-looping the entity.  Fixes issues #185 (relay) and #206
+        (camera_360).
+        """
+        try:
+            setattr(self._device, self.entity_description.on_key, True)
+        except AttributeError:
+            LOGGER.debug(
+                "turn_on skipped for %s: service not available (no load/service?)",
+                self.entity_id,
+            )
 
     def turn_off(self, **kwargs) -> None:
-        """Turn the switch off."""
-        setattr(self._device, self.entity_description.on_key, False)
+        """Turn the switch off.
+
+        Same guard as turn_on — see that docstring.
+        """
+        try:
+            setattr(self._device, self.entity_description.on_key, False)
+        except AttributeError:
+            LOGGER.debug(
+                "turn_off skipped for %s: service not available (no load/service?)",
+                self.entity_id,
+            )
 
     @property
     def should_poll(self) -> bool:

--- a/tests/bosch_shc/test_alarm_control_panel.py
+++ b/tests/bosch_shc/test_alarm_control_panel.py
@@ -73,10 +73,11 @@ def test_alarm_state_alarm_off_falls_through_to_arming_state():
     assert panel.alarm_state == AlarmControlPanelState.DISARMED
 
 
-def test_alarm_state_alarm_muted_falls_through_to_arming_state():
-    """ALARM_MUTED is NOT explicitly handled — falls through to ArmingState logic."""
+def test_alarm_state_alarm_muted_returns_triggered():
+    """ALARM_MUTED means the alarm fired but the siren was silenced — alarm is NOT cleared.
+    Must map to TRIGGERED (not fall through to ArmingState which would show ARMING/DISARMED)."""
     panel = _panel(alarm_state=AlarmState.ALARM_MUTED, arming_state=ArmingState.SYSTEM_ARMING)
-    assert panel.alarm_state == AlarmControlPanelState.ARMING
+    assert panel.alarm_state == AlarmControlPanelState.TRIGGERED
 
 
 # ---------------------------------------------------------------------------

--- a/tests/bosch_shc/test_alarm_control_panel.py
+++ b/tests/bosch_shc/test_alarm_control_panel.py
@@ -1,0 +1,302 @@
+"""Isolation-safe unit tests for IntrusionSystemAlarmControlPanel.
+
+Pattern: Cls.__new__(Cls) bypasses SHCEntity/__init__ (needs hass/registry).
+All pure-logic properties are exercised without a HA harness.
+PIN_EVERY_MODE: one test per discrete enum value + None/garbage fallback.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from boschshcpy import SHCIntrusionSystem
+from homeassistant.components.alarm_control_panel.const import (
+    AlarmControlPanelEntityFeature,
+    AlarmControlPanelState,
+)
+
+from custom_components.bosch_shc.alarm_control_panel import (
+    IntrusionSystemAlarmControlPanel,
+)
+
+AlarmState = SHCIntrusionSystem.AlarmState
+ArmingState = SHCIntrusionSystem.ArmingState
+Profile = SHCIntrusionSystem.Profile
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _panel(
+    alarm_state=AlarmState.ALARM_OFF,
+    arming_state=ArmingState.SYSTEM_DISARMED,
+    profile=Profile.FULL_PROTECTION,
+    system_availability=True,
+    name="Intrusion",
+    manufacturer="Bosch",
+    device_model="Alarm",
+    root_device_id="root-1",
+    device_id="dev-1",
+):
+    panel = IntrusionSystemAlarmControlPanel.__new__(IntrusionSystemAlarmControlPanel)
+    panel._device = SimpleNamespace(
+        alarm_state=alarm_state,
+        arming_state=arming_state,
+        active_configuration_profile=profile,
+        system_availability=system_availability,
+        name=name,
+        manufacturer=manufacturer,
+        device_model=device_model,
+        root_device_id=root_device_id,
+        id=device_id,
+    )
+    return panel
+
+
+# ---------------------------------------------------------------------------
+# alarm_state — AlarmState takes priority over ArmingState
+# ---------------------------------------------------------------------------
+
+def test_alarm_state_alarm_on_returns_triggered():
+    panel = _panel(alarm_state=AlarmState.ALARM_ON)
+    assert panel.alarm_state == AlarmControlPanelState.TRIGGERED
+
+
+def test_alarm_state_pre_alarm_returns_pending():
+    panel = _panel(alarm_state=AlarmState.PRE_ALARM)
+    assert panel.alarm_state == AlarmControlPanelState.PENDING
+
+
+def test_alarm_state_alarm_off_falls_through_to_arming_state():
+    """ALARM_OFF is NOT explicitly handled — falls through to ArmingState logic."""
+    panel = _panel(alarm_state=AlarmState.ALARM_OFF, arming_state=ArmingState.SYSTEM_DISARMED)
+    assert panel.alarm_state == AlarmControlPanelState.DISARMED
+
+
+def test_alarm_state_alarm_muted_falls_through_to_arming_state():
+    """ALARM_MUTED is NOT explicitly handled — falls through to ArmingState logic."""
+    panel = _panel(alarm_state=AlarmState.ALARM_MUTED, arming_state=ArmingState.SYSTEM_ARMING)
+    assert panel.alarm_state == AlarmControlPanelState.ARMING
+
+
+# ---------------------------------------------------------------------------
+# alarm_state — ArmingState (when alarm_state is ALARM_OFF)
+# ---------------------------------------------------------------------------
+
+def test_arming_state_system_arming_returns_arming():
+    panel = _panel(alarm_state=AlarmState.ALARM_OFF, arming_state=ArmingState.SYSTEM_ARMING)
+    assert panel.alarm_state == AlarmControlPanelState.ARMING
+
+
+def test_arming_state_system_disarmed_returns_disarmed():
+    panel = _panel(alarm_state=AlarmState.ALARM_OFF, arming_state=ArmingState.SYSTEM_DISARMED)
+    assert panel.alarm_state == AlarmControlPanelState.DISARMED
+
+
+# ---------------------------------------------------------------------------
+# alarm_state — SYSTEM_ARMED branches by active_configuration_profile
+# ---------------------------------------------------------------------------
+
+def test_arming_state_armed_full_protection_returns_armed_away():
+    panel = _panel(
+        alarm_state=AlarmState.ALARM_OFF,
+        arming_state=ArmingState.SYSTEM_ARMED,
+        profile=Profile.FULL_PROTECTION,
+    )
+    assert panel.alarm_state == AlarmControlPanelState.ARMED_AWAY
+
+
+def test_arming_state_armed_partial_protection_returns_armed_home():
+    panel = _panel(
+        alarm_state=AlarmState.ALARM_OFF,
+        arming_state=ArmingState.SYSTEM_ARMED,
+        profile=Profile.PARTIAL_PROTECTION,
+    )
+    assert panel.alarm_state == AlarmControlPanelState.ARMED_HOME
+
+
+def test_arming_state_armed_custom_protection_returns_armed_custom_bypass():
+    panel = _panel(
+        alarm_state=AlarmState.ALARM_OFF,
+        arming_state=ArmingState.SYSTEM_ARMED,
+        profile=Profile.CUSTOM_PROTECTION,
+    )
+    assert panel.alarm_state == AlarmControlPanelState.ARMED_CUSTOM_BYPASS
+
+
+def test_arming_state_armed_unknown_profile_returns_none():
+    """SYSTEM_ARMED with an unrecognised profile falls off all branches → None."""
+    panel = _panel(
+        alarm_state=AlarmState.ALARM_OFF,
+        arming_state=ArmingState.SYSTEM_ARMED,
+    )
+    panel._device.active_configuration_profile = "GARBAGE_PROFILE"
+    assert panel.alarm_state is None
+
+
+def test_alarm_state_none_active_profile_returns_none():
+    """active_configuration_profile=None with SYSTEM_ARMED → None."""
+    panel = _panel(
+        alarm_state=AlarmState.ALARM_OFF,
+        arming_state=ArmingState.SYSTEM_ARMED,
+    )
+    panel._device.active_configuration_profile = None
+    assert panel.alarm_state is None
+
+
+# ---------------------------------------------------------------------------
+# supported_features
+# ---------------------------------------------------------------------------
+
+def test_supported_features_contains_arm_away():
+    panel = _panel()
+    assert panel.supported_features & AlarmControlPanelEntityFeature.ARM_AWAY
+
+
+def test_supported_features_contains_arm_home():
+    panel = _panel()
+    assert panel.supported_features & AlarmControlPanelEntityFeature.ARM_HOME
+
+
+def test_supported_features_contains_arm_custom_bypass():
+    panel = _panel()
+    assert panel.supported_features & AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS
+
+
+def test_supported_features_does_not_contain_arm_night():
+    panel = _panel()
+    assert not (panel.supported_features & AlarmControlPanelEntityFeature.ARM_NIGHT)
+
+
+# ---------------------------------------------------------------------------
+# code_format / code_arm_required
+# ---------------------------------------------------------------------------
+
+def test_code_format_is_none():
+    assert _panel().code_format is None
+
+
+def test_code_arm_required_is_false():
+    assert _panel().code_arm_required is False
+
+
+# ---------------------------------------------------------------------------
+# availability
+# ---------------------------------------------------------------------------
+
+def test_available_true_when_system_available():
+    assert _panel(system_availability=True).available is True
+
+
+def test_available_false_when_system_unavailable():
+    assert _panel(system_availability=False).available is False
+
+
+# ---------------------------------------------------------------------------
+# should_poll
+# ---------------------------------------------------------------------------
+
+def test_should_poll_is_false():
+    assert _panel().should_poll is False
+
+
+# ---------------------------------------------------------------------------
+# name / device_id / manufacturer
+# ---------------------------------------------------------------------------
+
+def test_name_delegates_to_device():
+    assert _panel(name="My Alarm").name == "My Alarm"
+
+
+def test_device_id_delegates_to_device():
+    assert _panel(device_id="shc-alarm-42").device_id == "shc-alarm-42"
+
+
+def test_manufacturer_delegates_to_device():
+    assert _panel(manufacturer="Bosch GmbH").manufacturer == "Bosch GmbH"
+
+
+# ---------------------------------------------------------------------------
+# device_info
+# ---------------------------------------------------------------------------
+
+def test_device_info_structure():
+    panel = _panel(
+        name="Alarm Panel",
+        manufacturer="Bosch",
+        device_model="IDS",
+        root_device_id="root-99",
+        device_id="ids-1",
+    )
+    info = panel.device_info
+    assert ("bosch_shc", "ids-1") in info["identifiers"]
+    assert info["name"] == "Alarm Panel"
+    assert info["manufacturer"] == "Bosch"
+    assert info["model"] == "IDS"
+    assert info["via_device"] == ("bosch_shc", "root-99")
+
+
+# ---------------------------------------------------------------------------
+# unique_id (set during __init__ — verify via __new__ + manual construction)
+# ---------------------------------------------------------------------------
+
+def test_unique_id_composed_from_root_and_device_id():
+    panel = IntrusionSystemAlarmControlPanel.__new__(IntrusionSystemAlarmControlPanel)
+    panel._device = SimpleNamespace(
+        root_device_id="root-abc",
+        id="dev-xyz",
+        alarm_state=AlarmState.ALARM_OFF,
+        arming_state=ArmingState.SYSTEM_DISARMED,
+        active_configuration_profile=Profile.FULL_PROTECTION,
+        system_availability=True,
+        name="Test",
+        manufacturer="Bosch",
+        device_model="M1",
+    )
+    panel._entry_id = "entry-1"
+    panel._attr_unique_id = f"{panel._device.root_device_id}_{panel._device.id}"
+    assert panel._attr_unique_id == "root-abc_dev-xyz"
+
+
+# ---------------------------------------------------------------------------
+# arm/disarm action delegation
+# ---------------------------------------------------------------------------
+
+def test_alarm_disarm_calls_device_disarm():
+    calls = []
+    panel = _panel()
+    panel._device.disarm = lambda: calls.append("disarm")
+    panel.alarm_disarm()
+    assert calls == ["disarm"]
+
+
+def test_alarm_arm_away_calls_arm_full_protection():
+    calls = []
+    panel = _panel()
+    panel._device.arm_full_protection = lambda: calls.append("arm_full_protection")
+    panel.alarm_arm_away()
+    assert calls == ["arm_full_protection"]
+
+
+def test_alarm_arm_home_calls_arm_partial_protection():
+    calls = []
+    panel = _panel()
+    panel._device.arm_partial_protection = lambda: calls.append("arm_partial_protection")
+    panel.alarm_arm_home()
+    assert calls == ["arm_partial_protection"]
+
+
+def test_alarm_arm_custom_bypass_calls_arm_individual_protection():
+    calls = []
+    panel = _panel()
+    panel._device.arm_individual_protection = lambda: calls.append("arm_individual_protection")
+    panel.alarm_arm_custom_bypass()
+    assert calls == ["arm_individual_protection"]
+
+
+def test_alarm_mute_calls_device_mute():
+    calls = []
+    panel = _panel()
+    panel._device.mute = lambda: calls.append("mute")
+    panel.alarm_mute()
+    assert calls == ["mute"]

--- a/tests/bosch_shc/test_button.py
+++ b/tests/bosch_shc/test_button.py
@@ -1,0 +1,140 @@
+"""Isolation-safe unit tests for button.py (SHCRelayButton).
+
+Pattern: Cls.__new__(Cls) bypasses SHCEntity.__init__ (needs hass/registry).
+We only set the attributes the class under test actually reads.
+"""
+
+from types import SimpleNamespace
+
+from custom_components.bosch_shc.button import SHCRelayButton
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_device(
+    name: str = "Relay 1",
+    device_id: str = "hdm:HomeMaticIP:abc123",
+    root_device_id: str = "64:da:a0:00:00:01",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        id=device_id,
+        root_device_id=root_device_id,
+    )
+
+
+def _relay_button(
+    name: str = "Relay 1",
+    device_id: str = "hdm:HomeMaticIP:abc123",
+    root_device_id: str = "64:da:a0:00:00:01",
+    attr_name: str | None = None,
+) -> SHCRelayButton:
+    """Create an SHCRelayButton bypassing SHCEntity.__init__."""
+    btn = SHCRelayButton.__new__(SHCRelayButton)
+    dev = _make_device(name=name, device_id=device_id, root_device_id=root_device_id)
+    btn._device = dev
+    # Replicate the __init__ logic without calling super().__init__
+    btn._attr_name = (
+        f"{dev.name}" if attr_name is None else f"{dev.name} {attr_name}"
+    )
+    btn._attr_unique_id = (
+        f"{dev.root_device_id}_{dev.id}"
+        if attr_name is None
+        else f"{dev.root_device_id}_{dev.id}_{attr_name.lower()}"
+    )
+    return btn
+
+
+# ---------------------------------------------------------------------------
+# Tests: attr_name=None (default / single-relay)
+# ---------------------------------------------------------------------------
+
+def test_name_without_attr_name():
+    btn = _relay_button(name="Keller Relay", attr_name=None)
+    assert btn._attr_name == "Keller Relay"
+
+
+def test_unique_id_without_attr_name():
+    btn = _relay_button(
+        root_device_id="64:da:a0:00:00:01",
+        device_id="hdm:HomeMaticIP:abc123",
+        attr_name=None,
+    )
+    assert btn._attr_unique_id == "64:da:a0:00:00:01_hdm:HomeMaticIP:abc123"
+
+
+# ---------------------------------------------------------------------------
+# Tests: attr_name provided (multi-relay / named channel)
+# ---------------------------------------------------------------------------
+
+def test_name_with_attr_name():
+    btn = _relay_button(name="Garage", attr_name="CH1")
+    assert btn._attr_name == "Garage CH1"
+
+
+def test_unique_id_with_attr_name_lowercased():
+    btn = _relay_button(
+        root_device_id="64:da:a0:00:00:02",
+        device_id="hdm:HomeMaticIP:xyz789",
+        attr_name="Channel A",
+    )
+    assert btn._attr_unique_id == "64:da:a0:00:00:02_hdm:HomeMaticIP:xyz789_channel a"
+
+
+def test_unique_id_attr_name_already_lowercase():
+    btn = _relay_button(
+        root_device_id="root1",
+        device_id="dev1",
+        attr_name="impulse",
+    )
+    assert btn._attr_unique_id == "root1_dev1_impulse"
+
+
+# ---------------------------------------------------------------------------
+# Tests: press() delegates to device
+# ---------------------------------------------------------------------------
+
+def test_press_calls_trigger_impulse_state():
+    btn = _relay_button()
+    triggered = []
+    btn._device.trigger_impulse_state = lambda: triggered.append(True)
+    btn.press()
+    assert triggered == [True]
+
+
+def test_press_called_twice_triggers_twice():
+    btn = _relay_button()
+    count = []
+    btn._device.trigger_impulse_state = lambda: count.append(1)
+    btn.press()
+    btn.press()
+    assert len(count) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: class-level / structural properties
+# ---------------------------------------------------------------------------
+
+def test_shcrelaybutton_is_button_entity():
+    from homeassistant.components.button import ButtonEntity
+    assert issubclass(SHCRelayButton, ButtonEntity)
+
+
+def test_shcrelaybutton_is_shcentity():
+    from custom_components.bosch_shc.entity import SHCEntity
+    assert issubclass(SHCRelayButton, SHCEntity)
+
+
+def test_no_device_class_set():
+    """SHCRelayButton does not declare a device_class; ButtonEntity default is None."""
+    btn = _relay_button()
+    # _attr_device_class should not be set on the instance (falls through to class None)
+    assert not hasattr(btn, "_attr_device_class") or btn._attr_device_class is None
+
+
+def test_no_entity_category_set():
+    """SHCRelayButton is a primary entity — no entity_category set."""
+    btn = _relay_button()
+    assert not hasattr(btn, "_attr_entity_category") or btn._attr_entity_category is None

--- a/tests/bosch_shc/test_climate.py
+++ b/tests/bosch_shc/test_climate.py
@@ -44,6 +44,8 @@ def _make_device(
     setpoint_temperature=20.0,
     temperature=19.0,
     operation_mode_value="AUTOMATIC",
+    supports_cooling=False,
+    cooling_mode=False,
 ):
     from boschshcpy.services_impl import RoomClimateControlService
 
@@ -56,6 +58,8 @@ def _make_device(
         setpoint_temperature=setpoint_temperature,
         temperature=temperature,
         operation_mode=op,
+        supports_cooling=supports_cooling,
+        cooling_mode=cooling_mode,
         root_device_id="test-root",
         id="test-id",
     )
@@ -258,3 +262,129 @@ class TestNormalHeatSetTemp:
         entity, written = self._entity_capturing_writes()
         _run_async(entity.async_set_temperature(**{ATTR_TEMPERATURE: 31.0}))
         assert written == [], "Value above max_temp must not be written"
+
+
+# ---------------------------------------------------------------------------
+# PR #304 — COOL HVACMode on ClimateControl (supports_cooling)
+# ---------------------------------------------------------------------------
+
+def _make_device_cooling(
+    *,
+    supports_cooling=True,
+    cooling_mode=False,
+    summer_mode=False,
+    operation_mode_value="AUTOMATIC",
+):
+    from boschshcpy.services_impl import RoomClimateControlService
+
+    op = RoomClimateControlService.OperationMode(operation_mode_value)
+    return SimpleNamespace(
+        boost_mode=False,
+        low=False,
+        summer_mode=summer_mode,
+        supports_boost_mode=False,
+        supports_cooling=supports_cooling,
+        cooling_mode=cooling_mode,
+        setpoint_temperature=20.0,
+        temperature=19.0,
+        operation_mode=op,
+        root_device_id="test-root",
+        id="test-id",
+    )
+
+
+class TestCoolingHvacMode:
+    """PR #304: hvac_mode returns COOL when supports_cooling and cooling_mode."""
+
+    def test_hvac_mode_cool_when_cooling_active(self):
+        from homeassistant.components.climate.const import HVACMode
+        device = _make_device_cooling(supports_cooling=True, cooling_mode=True)
+        entity = _make_entity(device)
+        assert entity.hvac_mode == HVACMode.COOL
+
+    def test_hvac_mode_auto_when_not_cooling(self):
+        from homeassistant.components.climate.const import HVACMode
+        device = _make_device_cooling(supports_cooling=True, cooling_mode=False,
+                                      operation_mode_value="AUTOMATIC")
+        entity = _make_entity(device)
+        assert entity.hvac_mode == HVACMode.AUTO
+
+    def test_hvac_modes_includes_cool_when_supported(self):
+        from homeassistant.components.climate.const import HVACMode
+        device = _make_device_cooling(supports_cooling=True)
+        entity = _make_entity(device)
+        assert HVACMode.COOL in entity.hvac_modes
+
+    def test_hvac_modes_excludes_cool_when_not_supported(self):
+        from homeassistant.components.climate.const import HVACMode
+        device = _make_device_cooling(supports_cooling=False)
+        entity = _make_entity(device)
+        assert HVACMode.COOL not in entity.hvac_modes
+
+    def test_set_hvac_mode_cool_sets_cooling_mode(self):
+        from homeassistant.components.climate.const import HVACMode
+        device = _make_device_cooling(supports_cooling=True, cooling_mode=False)
+        entity = _make_entity(device)
+        written = {}
+
+        async def _executor(func, *args):
+            if func is setattr and len(args) == 3:
+                written[args[1]] = args[2]
+            else:
+                func(*args)
+
+        entity.hass = _make_hass(_executor)
+        _run_async(entity.async_set_hvac_mode(HVACMode.COOL))
+        assert written.get("cooling_mode") is True
+        assert written.get("summer_mode") is False
+
+    def test_set_hvac_mode_auto_clears_cooling_mode(self):
+        from homeassistant.components.climate.const import HVACMode
+        device = _make_device_cooling(supports_cooling=True, cooling_mode=True,
+                                      operation_mode_value="AUTOMATIC")
+        entity = _make_entity(device)
+        written = {}
+
+        async def _executor(func, *args):
+            if func is setattr and len(args) == 3:
+                written[args[1]] = args[2]
+            else:
+                func(*args)
+
+        entity.hass = _make_hass(_executor)
+        _run_async(entity.async_set_hvac_mode(HVACMode.AUTO))
+        assert written.get("cooling_mode") is False
+
+    def test_set_hvac_mode_heat_clears_cooling_mode(self):
+        from homeassistant.components.climate.const import HVACMode
+        device = _make_device_cooling(supports_cooling=True, cooling_mode=True,
+                                      operation_mode_value="MANUAL")
+        entity = _make_entity(device)
+        written = {}
+
+        async def _executor(func, *args):
+            if func is setattr and len(args) == 3:
+                written[args[1]] = args[2]
+            else:
+                func(*args)
+
+        entity.hass = _make_hass(_executor)
+        _run_async(entity.async_set_hvac_mode(HVACMode.HEAT))
+        assert written.get("cooling_mode") is False
+
+    def test_set_hvac_mode_off_clears_cooling_mode(self):
+        from homeassistant.components.climate.const import HVACMode
+        device = _make_device_cooling(supports_cooling=True, cooling_mode=True)
+        entity = _make_entity(device)
+        written = {}
+
+        async def _executor(func, *args):
+            if func is setattr and len(args) == 3:
+                written[args[1]] = args[2]
+            else:
+                func(*args)
+
+        entity.hass = _make_hass(_executor)
+        _run_async(entity.async_set_hvac_mode(HVACMode.OFF))
+        assert written.get("cooling_mode") is False
+        assert written.get("summer_mode") is True

--- a/tests/bosch_shc/test_climate.py
+++ b/tests/bosch_shc/test_climate.py
@@ -1,0 +1,260 @@
+"""Regression tests for climate.py fixes.
+
+#273 — Setting temperature in BOOST mode must not surface an unhandled
+       exception. The SHC returns HTTP 400 / WRONG_THERMOSTAT_GROUP_MODE,
+       which boschshcpy raises as JSONRPCError (or SHCException). The HA
+       entity must:
+         (a) return early with a warning before ever writing the setpoint, and
+         (b) catch JSONRPCError/SHCException even if the early-return is missed.
+
+#242 — ECO / low preset: TRV_GEN2 is controlled via ROOM_CLIMATE_CONTROL.
+       Setting low=True on that entity is the correct path. Covered here by
+       verifying the preset_mode property and the temperature-skip in ECO.
+
+#253 — TRV_I is not in boschshcpy MODEL_MAPPING; no climate entity is created
+       by design (the device is not supported in boschshcpy). Documented, no
+       code change needed.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from boschshcpy.exceptions import JSONRPCError, SHCException
+from custom_components.bosch_shc.climate import ClimateControl
+from homeassistant.components.climate.const import (
+    PRESET_BOOST,
+    PRESET_ECO,
+    PRESET_NONE,
+)
+from homeassistant.const import ATTR_TEMPERATURE
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_device(
+    *,
+    boost_mode=False,
+    low=False,
+    summer_mode=False,
+    supports_boost_mode=True,
+    setpoint_temperature=20.0,
+    temperature=19.0,
+    operation_mode_value="AUTOMATIC",
+):
+    from boschshcpy.services_impl import RoomClimateControlService
+
+    op = RoomClimateControlService.OperationMode(operation_mode_value)
+    return SimpleNamespace(
+        boost_mode=boost_mode,
+        low=low,
+        summer_mode=summer_mode,
+        supports_boost_mode=supports_boost_mode,
+        setpoint_temperature=setpoint_temperature,
+        temperature=temperature,
+        operation_mode=op,
+        root_device_id="test-root",
+        id="test-id",
+    )
+
+
+def _make_entity(device):
+    """Build a ClimateControl without going through __init__ (no HA session)."""
+    entity = ClimateControl.__new__(ClimateControl)
+    entity._device = device
+    entity._name = "Test Climate"
+    entity._attr_unique_id = "test-root_test-id"
+    return entity
+
+
+def _run_async(coro):
+    """Run an async coroutine synchronously (no pytest-asyncio needed)."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _make_hass(executor_func=None):
+    """Build a minimal hass stub with a configurable executor."""
+    if executor_func is None:
+        async def executor_func(func, *args):
+            return func(*args)
+    return SimpleNamespace(async_add_executor_job=executor_func)
+
+
+# ---------------------------------------------------------------------------
+# #273 — BOOST mode: early-return guard (no write at all)
+# ---------------------------------------------------------------------------
+
+class TestBoostPresetGuard:
+    """When preset_mode == PRESET_BOOST, async_set_temperature must return
+    early — the setpoint setter must never be called."""
+
+    def _entity_with_write_tracker(self):
+        """Return (entity, written_list). Any setattr call appends to written."""
+        device = _make_device(boost_mode=True, operation_mode_value="AUTOMATIC")
+        entity = _make_entity(device)
+        written = []
+
+        async def _executor(func, *args):
+            # Record the setattr target attribute
+            if func is setattr and len(args) == 3:
+                written.append(args[1])  # attribute name
+            return func(*args)
+
+        entity.hass = _make_hass(_executor)
+        return entity, written
+
+    def test_preset_is_boost(self):
+        device = _make_device(boost_mode=True)
+        entity = _make_entity(device)
+        assert entity.preset_mode == PRESET_BOOST
+
+    def test_boost_set_temp_does_not_call_executor(self):
+        entity, written = self._entity_with_write_tracker()
+        _run_async(entity.async_set_temperature(**{ATTR_TEMPERATURE: 22.0}))
+        assert "setpoint_temperature" not in written, (
+            "setpoint_temperature must NOT be written while in BOOST"
+        )
+
+    def test_boost_set_temp_does_not_raise(self):
+        entity, _ = self._entity_with_write_tracker()
+        try:
+            _run_async(entity.async_set_temperature(**{ATTR_TEMPERATURE: 22.0}))
+        except Exception as exc:
+            pytest.fail(f"async_set_temperature raised in BOOST: {exc!r}")
+
+    def test_boost_set_temp_no_temperature_arg_does_not_raise(self):
+        entity, _ = self._entity_with_write_tracker()
+        _run_async(entity.async_set_temperature())  # no ATTR_TEMPERATURE
+
+
+# ---------------------------------------------------------------------------
+# #273 — JSONRPCError swallowed (safety net catch)
+# ---------------------------------------------------------------------------
+
+class TestBoostJsonRpcErrorSwallowed:
+    """If the SHC returns HTTP 400, the JSONRPCError must be caught;
+    no unhandled exception propagates to HA."""
+
+    def test_jsonrpc_error_is_swallowed(self):
+        device = _make_device(boost_mode=False, low=False, operation_mode_value="MANUAL")
+        entity = _make_entity(device)
+
+        call_count = [0]
+
+        async def _executor(func, *args):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise JSONRPCError(400, "WRONG_THERMOSTAT_GROUP_MODE")
+            return func(*args)
+
+        entity.hass = _make_hass(_executor)
+
+        try:
+            _run_async(entity.async_set_temperature(**{ATTR_TEMPERATURE: 22.0}))
+        except JSONRPCError as exc:
+            pytest.fail(f"JSONRPCError was not caught: {exc!r}")
+
+    def test_shcexception_is_swallowed(self):
+        device = _make_device(boost_mode=False, low=False, operation_mode_value="MANUAL")
+        entity = _make_entity(device)
+
+        async def _executor(func, *args):
+            raise SHCException("generic SHC error")
+
+        entity.hass = _make_hass(_executor)
+
+        try:
+            _run_async(entity.async_set_temperature(**{ATTR_TEMPERATURE: 21.0}))
+        except SHCException as exc:
+            pytest.fail(f"SHCException was not caught: {exc!r}")
+
+
+# ---------------------------------------------------------------------------
+# #242 — ECO / low preset: verified by design
+# ---------------------------------------------------------------------------
+
+class TestEcoPreset:
+    """preset_mode == PRESET_ECO when device.low is True; temperature write
+    is skipped in ECO mode."""
+
+    def test_preset_mode_eco_when_low(self):
+        device = _make_device(low=True)
+        entity = _make_entity(device)
+        assert entity.preset_mode == PRESET_ECO
+
+    def test_preset_mode_none_when_not_low_not_boost(self):
+        device = _make_device(low=False, boost_mode=False)
+        entity = _make_entity(device)
+        assert entity.preset_mode == PRESET_NONE
+
+    def test_eco_skips_set_temperature(self):
+        device = _make_device(low=True, operation_mode_value="MANUAL")
+        entity = _make_entity(device)
+        executor_calls = []
+
+        async def _executor(func, *args):
+            executor_calls.append(func)
+            return func(*args)
+
+        entity.hass = _make_hass(_executor)
+        _run_async(entity.async_set_temperature(**{ATTR_TEMPERATURE: 19.0}))
+        assert executor_calls == [], "No executor call expected in ECO mode"
+
+    def test_eco_does_not_raise(self):
+        device = _make_device(low=True, operation_mode_value="MANUAL")
+        entity = _make_entity(device)
+        entity.hass = _make_hass()
+        try:
+            _run_async(entity.async_set_temperature(**{ATTR_TEMPERATURE: 19.0}))
+        except Exception as exc:
+            pytest.fail(f"async_set_temperature raised in ECO: {exc!r}")
+
+
+# ---------------------------------------------------------------------------
+# Normal HEAT mode: temperature written and rounded
+# ---------------------------------------------------------------------------
+
+class TestNormalHeatSetTemp:
+    def _entity_capturing_writes(self):
+        device = _make_device(
+            boost_mode=False, low=False, summer_mode=False,
+            operation_mode_value="MANUAL",
+        )
+        entity = _make_entity(device)
+        written = []
+
+        async def _executor(func, *args):
+            if func is setattr and len(args) == 3:
+                written.append(args[2])  # value written
+            else:
+                func(*args)
+
+        entity.hass = _make_hass(_executor)
+        return entity, written
+
+    def test_heat_mode_sets_setpoint(self):
+        entity, written = self._entity_capturing_writes()
+        _run_async(entity.async_set_temperature(**{ATTR_TEMPERATURE: 21.5}))
+        assert written == [21.5], f"Expected [21.5], got {written}"
+
+    def test_temperature_rounded_to_half_degree(self):
+        entity, written = self._entity_capturing_writes()
+        _run_async(entity.async_set_temperature(**{ATTR_TEMPERATURE: 21.3}))
+        assert written == [21.5], f"Expected [21.5] (rounded), got {written}"
+
+    def test_temperature_below_min_not_written(self):
+        entity, written = self._entity_capturing_writes()
+        _run_async(entity.async_set_temperature(**{ATTR_TEMPERATURE: 4.0}))
+        assert written == [], "Value below min_temp must not be written"
+
+    def test_temperature_above_max_not_written(self):
+        entity, written = self._entity_capturing_writes()
+        _run_async(entity.async_set_temperature(**{ATTR_TEMPERATURE: 31.0}))
+        assert written == [], "Value above max_temp must not be written"

--- a/tests/bosch_shc/test_event_universal_switch.py
+++ b/tests/bosch_shc/test_event_universal_switch.py
@@ -1,0 +1,186 @@
+"""Regression tests for event.py UniversalSwitchEvent (#192).
+
+Issue #192: the SHC sends a Keypad service payload alongside a battery-level
+update, replaying a stale keyName/eventType/eventTimestamp.  This used to fire
+a phantom HA button event even though no key was actually pressed.
+
+Fix: _event_callback now guards on:
+  - eventtype must be a genuine press (PRESS_SHORT / PRESS_LONG / PRESS_LONG_RELEASED)
+  - eventtimestamp must have advanced since the last event that was fired
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from custom_components.bosch_shc.event import UniversalSwitchEvent
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PRESS_SHORT = SimpleNamespace(name="PRESS_SHORT")
+_PRESS_LONG = SimpleNamespace(name="PRESS_LONG")
+_PRESS_LONG_RELEASED = SimpleNamespace(name="PRESS_LONG_RELEASED")
+_SWITCH_ON = SimpleNamespace(name="SWITCH_ON")
+_SWITCH_OFF = SimpleNamespace(name="SWITCH_OFF")
+
+KEY_ID = "UPPER_BUTTON"
+
+
+def _make_entity(eventtype, eventtimestamp, root_device_id="root1", device_id="dev1"):
+    """Build a UniversalSwitchEvent bypassing SHCEntity.__init__."""
+    entity = UniversalSwitchEvent.__new__(UniversalSwitchEvent)
+
+    entity._device = SimpleNamespace(
+        name="Test Switch",
+        id=device_id,
+        root_device_id=root_device_id,
+        eventtype=eventtype,
+        eventtimestamp=eventtimestamp,
+    )
+    entity._key_id = KEY_ID
+    entity._last_fired_timestamp = -1
+    entity._attr_unique_id = f"{root_device_id}_{device_id}_{KEY_ID}"
+    entity.entity_id = f"event.test_switch_button_{KEY_ID.lower()}"
+
+    # HA EventEntity methods we need to observe / stub
+    entity._trigger_event = MagicMock()
+    entity.schedule_update_ha_state = MagicMock()
+    # device_id is a property on SHCEntity reading _device.id — already set above
+
+    return entity
+
+
+# ---------------------------------------------------------------------------
+# Guard: eventtype must be a press
+# ---------------------------------------------------------------------------
+
+class TestEventTypeGuard:
+    """Non-press eventtype values must never produce a HA event."""
+
+    def test_switch_on_does_not_fire(self):
+        entity = _make_entity(eventtype=_SWITCH_ON, eventtimestamp=1000)
+        entity._event_callback()
+        entity._trigger_event.assert_not_called()
+        entity.schedule_update_ha_state.assert_not_called()
+
+    def test_switch_off_does_not_fire(self):
+        entity = _make_entity(eventtype=_SWITCH_OFF, eventtimestamp=1001)
+        entity._event_callback()
+        entity._trigger_event.assert_not_called()
+        entity.schedule_update_ha_state.assert_not_called()
+
+    def test_none_eventtype_does_not_fire(self):
+        entity = _make_entity(eventtype=None, eventtimestamp=1002)
+        entity._event_callback()
+        entity._trigger_event.assert_not_called()
+        entity.schedule_update_ha_state.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Guard: duplicate timestamp must not fire twice
+# ---------------------------------------------------------------------------
+
+class TestTimestampGuard:
+    """Identical eventTimestamp on successive callbacks = phantom / stale replay."""
+
+    def test_first_press_fires(self):
+        entity = _make_entity(eventtype=_PRESS_SHORT, eventtimestamp=5000)
+        entity._event_callback()
+        entity._trigger_event.assert_called_once()
+        assert entity._last_fired_timestamp == 5000
+
+    def test_second_call_same_ts_does_not_fire(self):
+        """Battery-update replaying the same stale Keypad state → must be swallowed."""
+        entity = _make_entity(eventtype=_PRESS_SHORT, eventtimestamp=5000)
+        entity._event_callback()   # first: fires
+        entity._event_callback()   # second: same ts → phantom, must NOT fire again
+        assert entity._trigger_event.call_count == 1
+
+    def test_new_ts_fires_again(self):
+        """A genuinely new keypress (different timestamp) must still fire."""
+        entity = _make_entity(eventtype=_PRESS_SHORT, eventtimestamp=5000)
+        entity._event_callback()
+        assert entity._trigger_event.call_count == 1
+
+        # Simulate a new keypress arriving with a higher timestamp
+        entity._device.eventtimestamp = 6000
+        entity._device.eventtype = _PRESS_LONG
+        entity._event_callback()
+        assert entity._trigger_event.call_count == 2
+        assert entity._last_fired_timestamp == 6000
+
+    def test_ts_zero_then_nonzero(self):
+        """Timestamp 0 is valid as an initial stale value; a real press at ts>0 must fire."""
+        entity = _make_entity(eventtype=_PRESS_SHORT, eventtimestamp=0)
+        # Simulate a stale state at ts=0 delivered at startup (should NOT fire
+        # because _last_fired_timestamp starts at -1, so ts=0 != -1 → will fire).
+        # The intent: we accept ts=0 as a genuine event if the device sends it.
+        entity._event_callback()
+        assert entity._trigger_event.call_count == 1
+        assert entity._last_fired_timestamp == 0
+
+        # A second call with the same ts=0 (stale replay) must NOT fire.
+        entity._event_callback()
+        assert entity._trigger_event.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Happy path: all three press types fire with correct event_type attribute
+# ---------------------------------------------------------------------------
+
+class TestPressTypesFire:
+    def test_press_short_fires(self):
+        entity = _make_entity(eventtype=_PRESS_SHORT, eventtimestamp=100)
+        entity._event_callback()
+        entity._trigger_event.assert_called_once()
+        args = entity._trigger_event.call_args[0]
+        assert args[0] == "PRESS_SHORT"
+
+    def test_press_long_fires(self):
+        entity = _make_entity(eventtype=_PRESS_LONG, eventtimestamp=200)
+        entity._event_callback()
+        entity._trigger_event.assert_called_once()
+        args = entity._trigger_event.call_args[0]
+        assert args[0] == "PRESS_LONG"
+
+    def test_press_long_released_fires(self):
+        entity = _make_entity(eventtype=_PRESS_LONG_RELEASED, eventtimestamp=300)
+        entity._event_callback()
+        entity._trigger_event.assert_called_once()
+        args = entity._trigger_event.call_args[0]
+        assert args[0] == "PRESS_LONG_RELEASED"
+
+    def test_schedule_update_called_on_fire(self):
+        entity = _make_entity(eventtype=_PRESS_SHORT, eventtimestamp=400)
+        entity._event_callback()
+        entity.schedule_update_ha_state.assert_called_once()
+
+    def test_schedule_update_not_called_when_suppressed(self):
+        """When callback is suppressed (non-press), schedule_update must not be called."""
+        entity = _make_entity(eventtype=_SWITCH_ON, eventtimestamp=500)
+        entity._event_callback()
+        entity.schedule_update_ha_state.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Core scenario: battery update simulation
+# Battery long-poll delivers same Keypad state → no phantom event
+# ---------------------------------------------------------------------------
+
+class TestBatteryUpdateSimulation:
+    """Reproduce the exact #192 scenario: battery update re-delivers stale Keypad."""
+
+    def test_phantom_event_not_fired_on_battery_update(self):
+        """After a genuine press, a battery update that replays the same
+        Keypad state must NOT generate a second HA event."""
+        entity = _make_entity(eventtype=_PRESS_SHORT, eventtimestamp=9999)
+
+        # First: genuine keypress event
+        entity._event_callback()
+        assert entity._trigger_event.call_count == 1
+
+        # Second: battery update triggers the same Keypad callback with stale data
+        # (same eventtype, same eventtimestamp — typical SHC behaviour for #192)
+        entity._event_callback()
+        assert entity._trigger_event.call_count == 1  # still 1, no phantom

--- a/tests/bosch_shc/test_heating_circuit.py
+++ b/tests/bosch_shc/test_heating_circuit.py
@@ -1,0 +1,43 @@
+"""Tests for the heating-circuit climate entity."""
+
+from types import SimpleNamespace
+
+from boschshcpy import SHCHeatingCircuit
+from homeassistant.components.climate.const import HVACAction, HVACMode
+
+from custom_components.bosch_shc.climate import HeatingCircuit
+
+OM = SHCHeatingCircuit.HeatingCircuitService.OperationMode
+
+
+def _hc(operation_mode, on, setpoint=21.0):
+    # bypass SHCEntity.__init__ (needs hass/registry); exercise the properties
+    hc = HeatingCircuit.__new__(HeatingCircuit)
+    hc._device = SimpleNamespace(
+        operation_mode=operation_mode, on=on, setpoint_temperature=setpoint
+    )
+    return hc
+
+
+def test_hvac_mode_auto():
+    assert _hc(OM.AUTOMATIC, False).hvac_mode == HVACMode.AUTO
+
+
+def test_hvac_mode_heat():
+    assert _hc(OM.MANUAL, True).hvac_mode == HVACMode.HEAT
+
+
+def test_hvac_action_heating_when_on():
+    assert _hc(OM.MANUAL, True).hvac_action == HVACAction.HEATING
+
+
+def test_hvac_action_idle_when_off():
+    assert _hc(OM.AUTOMATIC, False).hvac_action == HVACAction.IDLE
+
+
+def test_target_temperature_reads_setpoint():
+    assert _hc(OM.MANUAL, True, 19.5).target_temperature == 19.5
+
+
+def test_current_temperature_is_none():
+    assert _hc(OM.MANUAL, True).current_temperature is None

--- a/tests/bosch_shc/test_humidity_roomthermostat.py
+++ b/tests/bosch_shc/test_humidity_roomthermostat.py
@@ -1,0 +1,99 @@
+"""Regression test for issue #274: HumiditySensor wiring on Room Thermostat models.
+
+Issue: Humidity missing on Room Thermostat I / 230V (RTH2_230 family).
+
+Finding: NOT a code gap.  Both device_helper.wallthermostats (THB / BWTH /
+BWTH24 → SHCWallThermostat) and device_helper.roomthermostats (RTH2_BAT /
+RTH2_230 → SHCRoomThermostat2) are iterated at sensor.py:60-80 and each
+receives a HumiditySensor.  SHCRoomThermostat2 inherits SHCWallThermostat
+which mixes in _HumidityLevel, so .humidity is present on all covered models.
+
+This test documents the contract so that a future refactor cannot silently
+drop humidity registration for the room-thermostat branch.
+"""
+
+from types import SimpleNamespace
+
+from homeassistant.components.sensor import SensorDeviceClass
+
+from custom_components.bosch_shc.sensor import HumiditySensor
+
+
+def _make_humidity_sensor(humidity_value: float) -> HumiditySensor:
+    """Build a HumiditySensor bypassing SHCEntity.__init__ (no HASS required)."""
+    sensor = HumiditySensor.__new__(HumiditySensor)
+    sensor._device = SimpleNamespace(
+        humidity=humidity_value,
+        name="Room Thermostat",
+        id="roomthermostat-id",
+        root_device_id="shc-root-id",
+    )
+    sensor._attr_name = "Room Thermostat Humidity"
+    sensor._attr_unique_id = "shc-root-id_roomthermostat-id_humidity"
+    return sensor
+
+
+class TestHumiditySensorContract:
+    """Pin the HumiditySensor API so wiring regressions are caught immediately."""
+
+    def test_native_value_float(self):
+        """native_value returns the float humidity from the device."""
+        sensor = _make_humidity_sensor(55.0)
+        assert sensor.native_value == 55.0
+
+    def test_native_value_integer_compatible(self):
+        """Bosch API may return integer humidity; sensor must pass it through."""
+        sensor = _make_humidity_sensor(60)
+        assert sensor.native_value == 60
+
+    def test_device_class_is_humidity(self):
+        """device_class must be HUMIDITY so HA renders the correct icon and unit."""
+        sensor = _make_humidity_sensor(50.0)
+        assert sensor.device_class == SensorDeviceClass.HUMIDITY
+
+    def test_native_unit_is_percent(self):
+        """Unit of measurement must be % (PERCENTAGE)."""
+        sensor = _make_humidity_sensor(50.0)
+        assert sensor.native_unit_of_measurement == "%"
+
+    def test_zero_humidity(self):
+        """Edge case: 0 % humidity must not be falsy-filtered."""
+        sensor = _make_humidity_sensor(0.0)
+        assert sensor.native_value == 0.0
+
+    def test_max_humidity(self):
+        """Edge case: 100 % humidity."""
+        sensor = _make_humidity_sensor(100.0)
+        assert sensor.native_value == 100.0
+
+
+class TestRoomThermostatModelsHaveHumidity:
+    """Document which boschshcpy model classes expose .humidity.
+
+    SHCWallThermostat and SHCRoomThermostat2 both mix in _HumidityLevel.
+    If either loses that mixin the AttributeError below will surface the gap.
+    """
+
+    def test_wall_thermostat_has_humidity_attribute(self):
+        """SHCWallThermostat (THB / BWTH / BWTH24) must expose .humidity."""
+        from boschshcpy.models_impl import SHCWallThermostat
+        assert hasattr(SHCWallThermostat, "humidity"), (
+            "SHCWallThermostat lost the .humidity property — "
+            "check _HumidityLevel mixin inheritance"
+        )
+
+    def test_room_thermostat2_has_humidity_attribute(self):
+        """SHCRoomThermostat2 (RTH2_BAT / RTH2_230) must expose .humidity."""
+        from boschshcpy.models_impl import SHCRoomThermostat2
+        assert hasattr(SHCRoomThermostat2, "humidity"), (
+            "SHCRoomThermostat2 lost the .humidity property — "
+            "it must inherit SHCWallThermostat which mixes in _HumidityLevel"
+        )
+
+    def test_room_thermostat2_inherits_wall_thermostat(self):
+        """SHCRoomThermostat2 must subclass SHCWallThermostat for humidity to work."""
+        from boschshcpy.models_impl import SHCRoomThermostat2, SHCWallThermostat
+        assert issubclass(SHCRoomThermostat2, SHCWallThermostat), (
+            "SHCRoomThermostat2 no longer inherits SHCWallThermostat — "
+            "humidity sensor wiring in sensor.py:60-80 will silently fail"
+        )

--- a/tests/bosch_shc/test_light.py
+++ b/tests/bosch_shc/test_light.py
@@ -1,0 +1,363 @@
+"""Isolation-safe unit tests for light.py (LightSwitch).
+
+Tests bypass SHCEntity.__init__ via Cls.__new__(Cls) and set _device directly.
+No HA harness required.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from homeassistant.components.light import ColorMode
+from homeassistant.util import color as color_util
+
+from custom_components.bosch_shc.light import LightSwitch
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a LightSwitch without calling SHCEntity.__init__
+# ---------------------------------------------------------------------------
+
+def _make_device(
+    *,
+    binarystate=True,
+    brightness=100,
+    rgb=0xFFFFFF,
+    color=200,  # mired
+    supports_color_hsb=False,
+    supports_color_temp=False,
+    supports_brightness=True,
+    min_color_temperature=150,
+    max_color_temperature=500,
+):
+    return SimpleNamespace(
+        binarystate=binarystate,
+        brightness=brightness,
+        rgb=rgb,
+        color=color,
+        supports_color_hsb=supports_color_hsb,
+        supports_color_temp=supports_color_temp,
+        supports_brightness=supports_brightness,
+        min_color_temperature=min_color_temperature,
+        max_color_temperature=max_color_temperature,
+    )
+
+
+def _make_switch(device):
+    """Instantiate LightSwitch bypassing SHCEntity.__init__."""
+    sw = LightSwitch.__new__(LightSwitch)
+    sw._device = device
+    # Replay the relevant part of __init__ (color-mode detection only)
+    sw._attr_supported_color_modes = set()
+    if device.supports_color_hsb:
+        sw._attr_supported_color_modes.add(ColorMode.HS)
+        sw._attr_color_mode = ColorMode.HS
+    if device.supports_color_temp:
+        sw._attr_supported_color_modes.add(ColorMode.COLOR_TEMP)
+        sw._attr_color_mode = ColorMode.COLOR_TEMP
+    if device.supports_color_hsb or device.supports_color_temp:
+        sw._attr_min_color_temp_kelvin = color_util.color_temperature_mired_to_kelvin(
+            device.min_color_temperature
+        )
+        sw._attr_max_color_temp_kelvin = color_util.color_temperature_mired_to_kelvin(
+            device.max_color_temperature
+        )
+    if device.supports_brightness:
+        if len(sw._attr_supported_color_modes) == 0:
+            sw._attr_supported_color_modes.add(ColorMode.BRIGHTNESS)
+            sw._attr_color_mode = ColorMode.BRIGHTNESS
+    else:
+        if len(sw._attr_supported_color_modes) == 0:
+            sw._attr_supported_color_modes.add(ColorMode.ONOFF)
+            sw._attr_color_mode = ColorMode.ONOFF
+    return sw
+
+
+# ---------------------------------------------------------------------------
+# is_on
+# ---------------------------------------------------------------------------
+
+def test_is_on_true():
+    sw = _make_switch(_make_device(binarystate=True))
+    assert sw.is_on is True
+
+
+def test_is_on_false():
+    sw = _make_switch(_make_device(binarystate=False))
+    assert sw.is_on is False
+
+
+def test_is_on_none():
+    sw = _make_switch(_make_device(binarystate=None))
+    assert sw.is_on is None
+
+
+# ---------------------------------------------------------------------------
+# brightness  (device 0-100 → HA 0-255, rounded)
+# ---------------------------------------------------------------------------
+
+def test_brightness_full():
+    sw = _make_switch(_make_device(brightness=100))
+    assert sw.brightness == 255
+
+
+def test_brightness_zero():
+    sw = _make_switch(_make_device(brightness=0))
+    assert sw.brightness == 0
+
+
+def test_brightness_half():
+    # 50 * 255 / 100 = 127.5 → rounds to 128
+    sw = _make_switch(_make_device(brightness=50))
+    assert sw.brightness == round(50 * 255 / 100)
+
+
+def test_brightness_one_percent():
+    # 1 * 255 / 100 = 2.55 → rounds to 3
+    sw = _make_switch(_make_device(brightness=1))
+    assert sw.brightness == round(1 * 255 / 100)
+
+
+def test_brightness_99_percent():
+    sw = _make_switch(_make_device(brightness=99))
+    assert sw.brightness == round(99 * 255 / 100)
+
+
+# ---------------------------------------------------------------------------
+# color_temp_kelvin  (device in mired → HA kelvin)
+# ---------------------------------------------------------------------------
+
+def test_color_temp_kelvin_200mired():
+    sw = _make_switch(_make_device(supports_color_temp=True, color=200))
+    expected = color_util.color_temperature_mired_to_kelvin(200)
+    assert sw.color_temp_kelvin == expected
+
+
+def test_color_temp_kelvin_370mired():
+    sw = _make_switch(_make_device(supports_color_temp=True, color=370))
+    expected = color_util.color_temperature_mired_to_kelvin(370)
+    assert sw.color_temp_kelvin == expected
+
+
+def test_color_temp_kelvin_min_mired():
+    sw = _make_switch(_make_device(supports_color_temp=True, color=153))
+    expected = color_util.color_temperature_mired_to_kelvin(153)
+    assert sw.color_temp_kelvin == expected
+
+
+def test_color_temp_kelvin_max_mired():
+    sw = _make_switch(_make_device(supports_color_temp=True, color=500))
+    expected = color_util.color_temperature_mired_to_kelvin(500)
+    assert sw.color_temp_kelvin == expected
+
+
+# ---------------------------------------------------------------------------
+# hs_color  (device RGB int → HA (h, s))
+# ---------------------------------------------------------------------------
+
+def test_hs_color_white():
+    sw = _make_switch(_make_device(supports_color_hsb=True, rgb=0xFFFFFF))
+    hs = sw.hs_color
+    expected = color_util.color_RGB_to_hs(255, 255, 255)
+    assert hs == expected
+
+
+def test_hs_color_red():
+    sw = _make_switch(_make_device(supports_color_hsb=True, rgb=0xFF0000))
+    hs = sw.hs_color
+    expected = color_util.color_RGB_to_hs(255, 0, 0)
+    assert hs == expected
+
+
+def test_hs_color_green():
+    sw = _make_switch(_make_device(supports_color_hsb=True, rgb=0x00FF00))
+    hs = sw.hs_color
+    expected = color_util.color_RGB_to_hs(0, 255, 0)
+    assert hs == expected
+
+
+def test_hs_color_blue():
+    sw = _make_switch(_make_device(supports_color_hsb=True, rgb=0x0000FF))
+    hs = sw.hs_color
+    expected = color_util.color_RGB_to_hs(0, 0, 255)
+    assert hs == expected
+
+
+def test_hs_color_black():
+    sw = _make_switch(_make_device(supports_color_hsb=True, rgb=0x000000))
+    hs = sw.hs_color
+    expected = color_util.color_RGB_to_hs(0, 0, 0)
+    assert hs == expected
+
+
+def test_hs_color_arbitrary():
+    # 0x1A2B3C → R=26, G=43, B=60
+    sw = _make_switch(_make_device(supports_color_hsb=True, rgb=0x1A2B3C))
+    hs = sw.hs_color
+    expected = color_util.color_RGB_to_hs(0x1A, 0x2B, 0x3C)
+    assert hs == expected
+
+
+# ---------------------------------------------------------------------------
+# supported_color_modes + color_mode (set in __init__)
+# ---------------------------------------------------------------------------
+
+def test_color_mode_onoff_only():
+    sw = _make_switch(_make_device(supports_brightness=False, supports_color_hsb=False, supports_color_temp=False))
+    assert sw._attr_color_mode == ColorMode.ONOFF
+    assert sw._attr_supported_color_modes == {ColorMode.ONOFF}
+
+
+def test_color_mode_brightness_only():
+    sw = _make_switch(_make_device(supports_brightness=True, supports_color_hsb=False, supports_color_temp=False))
+    assert sw._attr_color_mode == ColorMode.BRIGHTNESS
+    assert sw._attr_supported_color_modes == {ColorMode.BRIGHTNESS}
+
+
+def test_color_mode_hs_only():
+    sw = _make_switch(_make_device(supports_color_hsb=True, supports_color_temp=False, supports_brightness=True))
+    assert sw._attr_color_mode == ColorMode.HS
+    assert ColorMode.HS in sw._attr_supported_color_modes
+    # BRIGHTNESS must NOT be added when HS is present
+    assert ColorMode.BRIGHTNESS not in sw._attr_supported_color_modes
+
+
+def test_color_mode_color_temp_only():
+    sw = _make_switch(_make_device(supports_color_temp=True, supports_color_hsb=False, supports_brightness=True))
+    assert sw._attr_color_mode == ColorMode.COLOR_TEMP
+    assert ColorMode.COLOR_TEMP in sw._attr_supported_color_modes
+    assert ColorMode.BRIGHTNESS not in sw._attr_supported_color_modes
+
+
+def test_color_mode_hs_and_color_temp():
+    sw = _make_switch(_make_device(supports_color_hsb=True, supports_color_temp=True, supports_brightness=True))
+    assert ColorMode.HS in sw._attr_supported_color_modes
+    assert ColorMode.COLOR_TEMP in sw._attr_supported_color_modes
+    assert ColorMode.BRIGHTNESS not in sw._attr_supported_color_modes
+    # color_mode ends up COLOR_TEMP (last assignment in __init__)
+    assert sw._attr_color_mode == ColorMode.COLOR_TEMP
+
+
+def test_min_max_color_temp_kelvin_set_when_color_hsb():
+    sw = _make_switch(_make_device(
+        supports_color_hsb=True,
+        min_color_temperature=150,
+        max_color_temperature=500,
+    ))
+    assert sw._attr_min_color_temp_kelvin == color_util.color_temperature_mired_to_kelvin(150)
+    assert sw._attr_max_color_temp_kelvin == color_util.color_temperature_mired_to_kelvin(500)
+
+
+def test_min_max_color_temp_kelvin_set_when_color_temp():
+    sw = _make_switch(_make_device(
+        supports_color_temp=True,
+        min_color_temperature=153,
+        max_color_temperature=454,
+    ))
+    assert sw._attr_min_color_temp_kelvin == color_util.color_temperature_mired_to_kelvin(153)
+    assert sw._attr_max_color_temp_kelvin == color_util.color_temperature_mired_to_kelvin(454)
+
+
+# ---------------------------------------------------------------------------
+# turn_on logic (brightness / color_temp / hs_color + binarystate)
+# ---------------------------------------------------------------------------
+
+def test_turn_on_sets_brightness():
+    device = _make_device(binarystate=True, brightness=50, supports_brightness=True)
+    sw = _make_switch(device)
+    sw.turn_on(brightness=128)
+    # 128 * 100 / 255 = 50.196... → max(round, 1) = 50
+    assert device.brightness == max(round(128 * 100 / 255), 1)
+
+
+def test_turn_on_brightness_minimum_clamps_to_1():
+    device = _make_device(binarystate=True, supports_brightness=True)
+    sw = _make_switch(device)
+    sw.turn_on(brightness=1)
+    # 1 * 100 / 255 = 0.39 → round = 0 → max(0, 1) = 1
+    assert device.brightness == 1
+
+
+def test_turn_on_brightness_zero_clamps_to_1():
+    device = _make_device(binarystate=True, supports_brightness=True)
+    sw = _make_switch(device)
+    sw.turn_on(brightness=0)
+    assert device.brightness == 1
+
+
+def test_turn_on_sets_color_temp():
+    device = _make_device(binarystate=True, supports_color_temp=True, color=200)
+    sw = _make_switch(device)
+    sw.turn_on(color_temp_kelvin=4000)
+    expected_mired = color_util.color_temperature_kelvin_to_mired(4000)
+    assert device.color == expected_mired
+
+
+def test_turn_on_sets_hs_color():
+    device = _make_device(binarystate=True, supports_color_hsb=True, rgb=0)
+    sw = _make_switch(device)
+    sw.turn_on(hs_color=(120.0, 100.0))  # pure green
+    rgb = color_util.color_hs_to_RGB(120.0, 100.0)
+    expected_raw = (rgb[0] << 16) + (rgb[1] << 8) + rgb[2]
+    assert device.rgb == expected_raw
+
+
+def test_turn_on_activates_binarystate_when_off():
+    device = _make_device(binarystate=False)
+    sw = _make_switch(device)
+    sw.turn_on()
+    assert device.binarystate is True
+
+
+def test_turn_on_does_not_double_set_binarystate_when_already_on():
+    """binarystate stays True — no redundant write."""
+    device = _make_device(binarystate=True)
+    sw = _make_switch(device)
+    original = device.binarystate
+    sw.turn_on()
+    assert device.binarystate == original
+
+
+def test_turn_on_no_kwargs_does_not_touch_brightness():
+    device = _make_device(binarystate=True, brightness=75, supports_brightness=True)
+    sw = _make_switch(device)
+    sw.turn_on()
+    assert device.brightness == 75  # unchanged
+
+
+def test_turn_on_brightness_ignored_when_not_supported():
+    device = _make_device(binarystate=True, brightness=50, supports_brightness=False)
+    sw = _make_switch(device)
+    sw.turn_on(brightness=200)
+    assert device.brightness == 50  # must not change
+
+
+def test_turn_on_color_temp_ignored_when_not_supported():
+    device = _make_device(binarystate=True, color=200, supports_color_temp=False)
+    sw = _make_switch(device)
+    sw.turn_on(color_temp_kelvin=3000)
+    assert device.color == 200  # must not change
+
+
+def test_turn_on_hs_color_ignored_when_not_supported():
+    device = _make_device(binarystate=True, rgb=0xFF0000, supports_color_hsb=False)
+    sw = _make_switch(device)
+    sw.turn_on(hs_color=(240.0, 100.0))
+    assert device.rgb == 0xFF0000  # must not change
+
+
+# ---------------------------------------------------------------------------
+# turn_off
+# ---------------------------------------------------------------------------
+
+def test_turn_off_sets_binarystate_false():
+    device = _make_device(binarystate=True)
+    sw = _make_switch(device)
+    sw.turn_off()
+    assert device.binarystate is False
+
+
+def test_turn_off_already_off_stays_off():
+    device = _make_device(binarystate=False)
+    sw = _make_switch(device)
+    sw.turn_off()
+    assert device.binarystate is False

--- a/tests/bosch_shc/test_light.py
+++ b/tests/bosch_shc/test_light.py
@@ -5,7 +5,6 @@ No HA harness required.
 """
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
 
 from homeassistant.components.light import ColorMode
 from homeassistant.util import color as color_util
@@ -53,7 +52,9 @@ def _make_switch(device):
         sw._attr_color_mode = ColorMode.HS
     if device.supports_color_temp:
         sw._attr_supported_color_modes.add(ColorMode.COLOR_TEMP)
-        sw._attr_color_mode = ColorMode.COLOR_TEMP
+        # Mirror the fixed __init__: COLOR_TEMP wins only when HS is NOT also present
+        if not device.supports_color_hsb:
+            sw._attr_color_mode = ColorMode.COLOR_TEMP
     if device.supports_color_hsb or device.supports_color_temp:
         sw._attr_min_color_temp_kelvin = color_util.color_temperature_mired_to_kelvin(
             device.min_color_temperature
@@ -120,6 +121,12 @@ def test_brightness_one_percent():
 def test_brightness_99_percent():
     sw = _make_switch(_make_device(brightness=99))
     assert sw.brightness == round(99 * 255 / 100)
+
+
+def test_brightness_none_guard():
+    """brightness property must return None when device reports None (e.g. unavailable)."""
+    sw = _make_switch(_make_device(brightness=None))
+    assert sw.brightness is None
 
 
 # ---------------------------------------------------------------------------
@@ -229,12 +236,13 @@ def test_color_mode_color_temp_only():
 
 
 def test_color_mode_hs_and_color_temp():
+    # When both HS and COLOR_TEMP are supported, HS takes priority as the
+    # default color_mode (richer capability; COLOR_TEMP no longer last-write-wins).
     sw = _make_switch(_make_device(supports_color_hsb=True, supports_color_temp=True, supports_brightness=True))
     assert ColorMode.HS in sw._attr_supported_color_modes
     assert ColorMode.COLOR_TEMP in sw._attr_supported_color_modes
     assert ColorMode.BRIGHTNESS not in sw._attr_supported_color_modes
-    # color_mode ends up COLOR_TEMP (last assignment in __init__)
-    assert sw._attr_color_mode == ColorMode.COLOR_TEMP
+    assert sw._attr_color_mode == ColorMode.HS
 
 
 def test_min_max_color_temp_kelvin_set_when_color_hsb():

--- a/tests/bosch_shc/test_logbook.py
+++ b/tests/bosch_shc/test_logbook.py
@@ -1,0 +1,138 @@
+"""Isolation-safe unit tests for logbook.py.
+
+Tests the pure inner function async_describe_bosch_shc_event directly by
+capturing it via a stub async_describe_event callback — no HA harness needed.
+PIN_EVERY_MODE: one test per discrete event_type branch + fallback variants.
+"""
+
+from types import SimpleNamespace
+
+from custom_components.bosch_shc.logbook import async_describe_events
+
+
+def _get_describer():
+    """Return the inner async_describe_bosch_shc_event function."""
+    captured = {}
+
+    def fake_async_describe_event(domain, event_name, fn):
+        captured["fn"] = fn
+
+    async_describe_events(hass=None, async_describe_event=fake_async_describe_event)
+    return captured["fn"]
+
+
+def _event(event_type, event_subtype="some_subtype", device_name="TestDevice"):
+    return SimpleNamespace(
+        data={
+            "name": device_name,
+            "event_type": event_type,
+            "event_subtype": event_subtype,
+        }
+    )
+
+
+describe = _get_describer()
+
+
+# ---------------------------------------------------------------------------
+# MOTION
+# ---------------------------------------------------------------------------
+
+def test_motion_event_name():
+    result = describe(_event("MOTION"))
+    assert result["name"] == "Bosch SHC"
+
+
+def test_motion_event_message_contains_device():
+    result = describe(_event("MOTION", device_name="Garten"))
+    assert "'Garten' motion event was fired." == result["message"]
+
+
+def test_motion_event_subtype_not_in_message():
+    result = describe(_event("MOTION", event_subtype="IGNORED_SUBTYPE"))
+    assert "IGNORED_SUBTYPE" not in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# ALARM
+# ---------------------------------------------------------------------------
+
+def test_alarm_event_name():
+    result = describe(_event("ALARM", event_subtype="INTRUSION_DETECTED"))
+    assert result["name"] == "Bosch SHC"
+
+
+def test_alarm_event_message_contains_device_and_subtype():
+    result = describe(_event("ALARM", event_subtype="INTRUSION_DETECTED", device_name="Eingang"))
+    assert result["message"] == "'Eingang' alarm event 'INTRUSION_DETECTED' was fired."
+
+
+def test_alarm_event_different_subtype():
+    result = describe(_event("ALARM", event_subtype="TILT_DETECTED", device_name="Fenster"))
+    assert "TILT_DETECTED" in result["message"]
+    assert "'Fenster'" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# SCENARIO
+# ---------------------------------------------------------------------------
+
+def test_scenario_event_name():
+    result = describe(_event("SCENARIO"))
+    assert result["name"] == "Bosch SHC"
+
+
+def test_scenario_event_message_contains_device():
+    result = describe(_event("SCENARIO", device_name="Szene1"))
+    assert result["message"] == "'Szene1' scenario trigger event was fired."
+
+
+def test_scenario_event_subtype_not_in_message():
+    result = describe(_event("SCENARIO", event_subtype="IGNORED"))
+    assert "IGNORED" not in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# Fallback / click event (any unknown event_type)
+# ---------------------------------------------------------------------------
+
+def test_unknown_event_type_falls_back_to_click_format():
+    result = describe(_event("PRESS_SHORT", event_subtype="TOP", device_name="Wandschalter"))
+    assert result["name"] == "Bosch SHC"
+    assert result["message"] == "'PRESS_SHORT' click event for Wandschalter button 'TOP' was fired."
+
+
+def test_unknown_event_type_includes_subtype():
+    result = describe(_event("PRESS_LONG", event_subtype="BOTTOM", device_name="Schalter"))
+    assert "BOTTOM" in result["message"]
+    assert "PRESS_LONG" in result["message"]
+
+
+def test_garbage_event_type_falls_back_gracefully():
+    result = describe(_event("!!!INVALID!!!", event_subtype="xyz", device_name="Dev"))
+    assert result["name"] == "Bosch SHC"
+    assert "!!!INVALID!!!" in result["message"]
+    assert "xyz" in result["message"]
+
+
+def test_empty_string_event_type_falls_back():
+    result = describe(_event("", event_subtype="sub", device_name="Dev"))
+    assert result["name"] == "Bosch SHC"
+    # empty string is not MOTION/ALARM/SCENARIO → click branch
+    assert "sub" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# Message structure invariants
+# ---------------------------------------------------------------------------
+
+def test_all_branches_return_name_and_message_keys():
+    for event_type in ("MOTION", "ALARM", "SCENARIO", "CLICK"):
+        result = describe(_event(event_type, event_subtype="sub", device_name="Dev"))
+        assert "name" in result, f"missing 'name' for {event_type}"
+        assert "message" in result, f"missing 'message' for {event_type}"
+
+
+def test_device_name_with_special_chars():
+    result = describe(_event("MOTION", device_name="Kamera 'Außen'"))
+    assert "Kamera 'Außen'" in result["message"]

--- a/tests/bosch_shc/test_number.py
+++ b/tests/bosch_shc/test_number.py
@@ -1,0 +1,194 @@
+"""Isolation-safe unit tests for the SHCNumber entity.
+
+Pattern: bypass SHCEntity.__init__ via Cls.__new__(Cls), set _device as
+SimpleNamespace, and assert pure property logic — no HA harness required.
+
+PIN_EVERY_MODE: one test class per entity characteristic (value, bounds, step,
+metadata) with boundary / default / None cases.
+"""
+
+from types import SimpleNamespace
+
+from custom_components.bosch_shc.number import SHCNumber
+from homeassistant.components.number import NumberDeviceClass
+from homeassistant.const import UnitOfTemperature
+from homeassistant.helpers.entity import EntityCategory
+
+
+def _make_number(
+    *,
+    offset=0.0,
+    min_offset=-5.0,
+    max_offset=5.0,
+    step_size=0.5,
+):
+    """Return an SHCNumber with _device set via SimpleNamespace (no HA init)."""
+    entity = SHCNumber.__new__(SHCNumber)
+    entity._device = SimpleNamespace(
+        offset=offset,
+        min_offset=min_offset,
+        max_offset=max_offset,
+        step_size=step_size,
+    )
+    return entity
+
+
+# ---------------------------------------------------------------------------
+# native_value
+# ---------------------------------------------------------------------------
+
+
+def test_native_value_positive():
+    entity = _make_number(offset=2.5)
+    assert entity.native_value == 2.5
+
+
+def test_native_value_negative():
+    entity = _make_number(offset=-3.0)
+    assert entity.native_value == -3.0
+
+
+def test_native_value_zero():
+    entity = _make_number(offset=0.0)
+    assert entity.native_value == 0.0
+
+
+def test_native_value_at_max():
+    entity = _make_number(offset=5.0, max_offset=5.0)
+    assert entity.native_value == 5.0
+
+
+def test_native_value_at_min():
+    entity = _make_number(offset=-5.0, min_offset=-5.0)
+    assert entity.native_value == -5.0
+
+
+# ---------------------------------------------------------------------------
+# native_min_value
+# ---------------------------------------------------------------------------
+
+
+def test_native_min_value_default():
+    entity = _make_number(min_offset=-5.0)
+    assert entity.native_min_value == -5.0
+
+
+def test_native_min_value_positive():
+    entity = _make_number(min_offset=0.0)
+    assert entity.native_min_value == 0.0
+
+
+def test_native_min_value_large_negative():
+    entity = _make_number(min_offset=-100.0)
+    assert entity.native_min_value == -100.0
+
+
+# ---------------------------------------------------------------------------
+# native_max_value
+# ---------------------------------------------------------------------------
+
+
+def test_native_max_value_default():
+    entity = _make_number(max_offset=5.0)
+    assert entity.native_max_value == 5.0
+
+
+def test_native_max_value_zero():
+    entity = _make_number(max_offset=0.0)
+    assert entity.native_max_value == 0.0
+
+
+def test_native_max_value_large():
+    entity = _make_number(max_offset=100.0)
+    assert entity.native_max_value == 100.0
+
+
+# ---------------------------------------------------------------------------
+# native_step
+# ---------------------------------------------------------------------------
+
+
+def test_native_step_half():
+    entity = _make_number(step_size=0.5)
+    assert entity.native_step == 0.5
+
+
+def test_native_step_one():
+    entity = _make_number(step_size=1.0)
+    assert entity.native_step == 1.0
+
+
+def test_native_step_fraction():
+    entity = _make_number(step_size=0.1)
+    assert abs(entity.native_step - 0.1) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# class-level metadata (device_class, unit, entity_category)
+# ---------------------------------------------------------------------------
+
+
+def test_device_class_is_temperature():
+    entity = _make_number()
+    assert entity.device_class == NumberDeviceClass.TEMPERATURE
+
+
+def test_native_unit_is_celsius():
+    entity = _make_number()
+    assert entity.native_unit_of_measurement == UnitOfTemperature.CELSIUS
+
+
+def test_entity_category_is_diagnostic():
+    entity = _make_number()
+    assert entity.entity_category == EntityCategory.DIAGNOSTIC
+
+
+# ---------------------------------------------------------------------------
+# set_native_value round-trip (write-through to _device.offset)
+# ---------------------------------------------------------------------------
+
+
+def test_set_native_value_positive():
+    entity = _make_number(offset=0.0)
+    entity.set_native_value(3.5)
+    assert entity._device.offset == 3.5
+
+
+def test_set_native_value_negative():
+    entity = _make_number(offset=0.0)
+    entity.set_native_value(-2.0)
+    assert entity._device.offset == -2.0
+
+
+def test_set_native_value_zero():
+    entity = _make_number(offset=5.0)
+    entity.set_native_value(0.0)
+    assert entity._device.offset == 0.0
+
+
+def test_set_native_value_at_boundary_max():
+    entity = _make_number(max_offset=5.0)
+    entity.set_native_value(5.0)
+    assert entity._device.offset == 5.0
+
+
+def test_set_native_value_at_boundary_min():
+    entity = _make_number(min_offset=-5.0)
+    entity.set_native_value(-5.0)
+    assert entity._device.offset == -5.0
+
+
+# ---------------------------------------------------------------------------
+# boundary consistency (min <= value <= max)
+# ---------------------------------------------------------------------------
+
+
+def test_bounds_consistency_default_range():
+    entity = _make_number(offset=0.0, min_offset=-5.0, max_offset=5.0)
+    assert entity.native_min_value <= entity.native_value <= entity.native_max_value
+
+
+def test_bounds_consistency_at_extremes():
+    for offset in (-5.0, 0.0, 5.0):
+        entity = _make_number(offset=offset, min_offset=-5.0, max_offset=5.0)
+        assert entity.native_min_value <= entity.native_value <= entity.native_max_value

--- a/tests/bosch_shc/test_number.py
+++ b/tests/bosch_shc/test_number.py
@@ -192,3 +192,43 @@ def test_bounds_consistency_at_extremes():
     for offset in (-5.0, 0.0, 5.0):
         entity = _make_number(offset=offset, min_offset=-5.0, max_offset=5.0)
         assert entity.native_min_value <= entity.native_value <= entity.native_max_value
+
+
+# ---------------------------------------------------------------------------
+# set_native_value clamping (out-of-range values are clamped, not passed through)
+# ---------------------------------------------------------------------------
+
+
+def test_set_native_value_above_max_clamps_to_max():
+    """Value above native_max_value must be clamped to max, never sent raw."""
+    entity = _make_number(offset=0.0, min_offset=-5.0, max_offset=5.0)
+    entity.set_native_value(10.0)
+    assert entity._device.offset == 5.0
+
+
+def test_set_native_value_below_min_clamps_to_min():
+    """Value below native_min_value must be clamped to min, never sent raw."""
+    entity = _make_number(offset=0.0, min_offset=-5.0, max_offset=5.0)
+    entity.set_native_value(-20.0)
+    assert entity._device.offset == -5.0
+
+
+def test_set_native_value_in_range_passes_through():
+    """In-range value must reach _device.offset unchanged."""
+    entity = _make_number(offset=0.0, min_offset=-5.0, max_offset=5.0)
+    entity.set_native_value(2.5)
+    assert entity._device.offset == 2.5
+
+
+def test_set_native_value_exactly_at_max_passes_through():
+    """Boundary-equal max must pass through, not be rejected."""
+    entity = _make_number(offset=0.0, min_offset=-5.0, max_offset=5.0)
+    entity.set_native_value(5.0)
+    assert entity._device.offset == 5.0
+
+
+def test_set_native_value_exactly_at_min_passes_through():
+    """Boundary-equal min must pass through, not be rejected."""
+    entity = _make_number(offset=0.0, min_offset=-5.0, max_offset=5.0)
+    entity.set_native_value(-5.0)
+    assert entity._device.offset == -5.0

--- a/tests/bosch_shc/test_smoke_detector_alarm.py
+++ b/tests/bosch_shc/test_smoke_detector_alarm.py
@@ -1,0 +1,49 @@
+"""Regression test for SmokeDetectorSensor.is_on alarm-state mapping (issue #191).
+
+Bug: is_on used `!= IDLE_OFF`, so INTRUSION_ALARM (set by the IDS on all smoke
+detectors when a burglar alarm fires) falsely reported every detector as smoky.
+Fix: is_on only returns True for PRIMARY_ALARM or SECONDARY_ALARM.
+"""
+
+from enum import Enum
+from types import SimpleNamespace
+
+from custom_components.bosch_shc.binary_sensor import SmokeDetectorSensor
+
+
+class _FakeAlarmState(Enum):
+    IDLE_OFF = "IDLE_OFF"
+    INTRUSION_ALARM = "INTRUSION_ALARM"
+    SECONDARY_ALARM = "SECONDARY_ALARM"
+    PRIMARY_ALARM = "PRIMARY_ALARM"
+
+
+def _sensor(alarm_state):
+    """Build a SmokeDetectorSensor without running __init__."""
+    s = SmokeDetectorSensor.__new__(SmokeDetectorSensor)
+    # AlarmService.State is referenced via SHCSmokeDetector.AlarmService.State in
+    # is_on — patch _device.alarmstate with the real imported enum so the
+    # identity check works correctly.
+    from boschshcpy import SHCSmokeDetector
+
+    state = SHCSmokeDetector.AlarmService.State[alarm_state.name]
+    s._device = SimpleNamespace(alarmstate=state)
+    return s
+
+
+def test_idle_off_is_not_smoke():
+    assert _sensor(_FakeAlarmState.IDLE_OFF).is_on is False
+
+
+def test_intrusion_alarm_does_not_trigger_smoke(
+):
+    """IDS intrusion alarm must NOT make smoke sensors report smoke (issue #191)."""
+    assert _sensor(_FakeAlarmState.INTRUSION_ALARM).is_on is False
+
+
+def test_primary_alarm_is_smoke():
+    assert _sensor(_FakeAlarmState.PRIMARY_ALARM).is_on is True
+
+
+def test_secondary_alarm_is_smoke():
+    assert _sensor(_FakeAlarmState.SECONDARY_ALARM).is_on is True

--- a/tests/bosch_shc/test_switch_service_none.py
+++ b/tests/bosch_shc/test_switch_service_none.py
@@ -1,0 +1,218 @@
+"""Regression tests for SHCSwitch when the underlying boschshcpy service is None.
+
+Covers:
+- Issue #185: MicromoduleRelay turn_on/turn_off raise AttributeError when no
+  load is connected (PowerSwitchService is None → switchstate setter crashes).
+- Issue #206: Camera360 turn_on/turn_off raise AttributeError when
+  PrivacyModeService is None → privacymode setter crashes.
+- Issue #246: silent_mode on_value / service mapping verified as correct; no
+  crash path exists (silentmode setter already guards for None service).
+"""
+
+from types import SimpleNamespace
+
+from boschshcpy import SHCThermostat
+
+from custom_components.bosch_shc.switch import SHCSwitch, SWITCH_TYPES
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_switch(description, **device_attrs):
+    """Build a bare SHCSwitch (bypassing SHCEntity.__init__) with a fake device."""
+    sw = SHCSwitch.__new__(SHCSwitch)
+    sw._device = SimpleNamespace(**device_attrs)
+    sw.entity_description = description
+    sw.entity_id = "switch.test"
+    return sw
+
+
+def _raising_property(exc_type=AttributeError):
+    """Return a SimpleNamespace property descriptor that raises on access/set."""
+
+    class _Raiser:
+        def __get__(self, obj, objtype=None):
+            raise exc_type("service is None")
+
+        def __set__(self, obj, value):
+            raise exc_type("service is None")
+
+    return _Raiser()
+
+
+# ---------------------------------------------------------------------------
+# Issue #185 — MicromoduleRelay with no load (PowerSwitch service is None)
+# ---------------------------------------------------------------------------
+
+
+class _RelayNoLoad:
+    """Simulates a MicromoduleRelay whose PowerSwitch service is None.
+
+    Both the getter and setter of `switchstate` raise AttributeError, which is
+    what boschshcpy does when `self._powerswitch_service` is None.
+    """
+
+    switchstate = _raising_property()
+
+
+def test_relay_no_load_is_on_returns_none():
+    """is_on must return None (not raise) when switchstate getter raises."""
+    sw = SHCSwitch.__new__(SHCSwitch)
+    sw._device = _RelayNoLoad()
+    sw.entity_description = SWITCH_TYPES["micromodule_relay_switch"]
+    assert sw.is_on is None
+
+
+def test_relay_no_load_turn_on_does_not_raise():
+    """turn_on must NOT propagate AttributeError when service is None."""
+    sw = SHCSwitch.__new__(SHCSwitch)
+    sw._device = _RelayNoLoad()
+    sw.entity_description = SWITCH_TYPES["micromodule_relay_switch"]
+    sw.entity_id = "switch.relay_test"
+    sw.turn_on()  # must not raise
+
+
+def test_relay_no_load_turn_off_does_not_raise():
+    """turn_off must NOT propagate AttributeError when service is None."""
+    sw = SHCSwitch.__new__(SHCSwitch)
+    sw._device = _RelayNoLoad()
+    sw.entity_description = SWITCH_TYPES["micromodule_relay_switch"]
+    sw.entity_id = "switch.relay_test"
+    sw.turn_off()  # must not raise
+
+
+def test_relay_with_load_turn_on_calls_setter():
+    """turn_on must write True to switchstate when the service exists."""
+    calls = []
+
+    class _RelayWithLoad:
+        @property
+        def switchstate(self):
+            return "OFF"
+
+        @switchstate.setter
+        def switchstate(self, value):
+            calls.append(value)
+
+    sw = SHCSwitch.__new__(SHCSwitch)
+    sw._device = _RelayWithLoad()
+    sw.entity_description = SWITCH_TYPES["micromodule_relay_switch"]
+    sw.entity_id = "switch.relay_loaded"
+    sw.turn_on()
+    assert calls == [True]
+
+
+def test_relay_with_load_turn_off_calls_setter():
+    """turn_off must write False to switchstate when the service exists."""
+    calls = []
+
+    class _RelayWithLoad:
+        @property
+        def switchstate(self):
+            return "ON"
+
+        @switchstate.setter
+        def switchstate(self, value):
+            calls.append(value)
+
+    sw = SHCSwitch.__new__(SHCSwitch)
+    sw._device = _RelayWithLoad()
+    sw.entity_description = SWITCH_TYPES["micromodule_relay_switch"]
+    sw.entity_id = "switch.relay_loaded"
+    sw.turn_off()
+    assert calls == [False]
+
+
+# ---------------------------------------------------------------------------
+# Issue #206 — Camera360 with no PrivacyMode service
+# ---------------------------------------------------------------------------
+
+
+class _Camera360NoPrivacy:
+    """Simulates SHCCamera360 where _privacymode_service is None.
+
+    boschshcpy's privacymode getter/setter both crash with AttributeError
+    when _privacymode_service is None (no guard in the Camera360 class).
+    """
+
+    privacymode = _raising_property()
+
+
+def test_camera360_no_privacy_service_is_on_returns_none():
+    """is_on must return None (not raise) when privacymode getter raises."""
+    sw = SHCSwitch.__new__(SHCSwitch)
+    sw._device = _Camera360NoPrivacy()
+    sw.entity_description = SWITCH_TYPES["camera360"]
+    assert sw.is_on is None
+
+
+def test_camera360_no_privacy_service_turn_on_does_not_raise():
+    """turn_on must NOT propagate AttributeError when privacy service is None."""
+    sw = SHCSwitch.__new__(SHCSwitch)
+    sw._device = _Camera360NoPrivacy()
+    sw.entity_description = SWITCH_TYPES["camera360"]
+    sw.entity_id = "switch.cam360_test"
+    sw.turn_on()  # must not raise
+
+
+def test_camera360_no_privacy_service_turn_off_does_not_raise():
+    """turn_off must NOT propagate AttributeError when privacy service is None."""
+    sw = SHCSwitch.__new__(SHCSwitch)
+    sw._device = _Camera360NoPrivacy()
+    sw.entity_description = SWITCH_TYPES["camera360"]
+    sw.entity_id = "switch.cam360_test"
+    sw.turn_off()  # must not raise
+
+
+def test_camera360_notification_none_is_on_returns_none():
+    """is_on for camera360_notification must return None when service getter raises."""
+    sw = SHCSwitch.__new__(SHCSwitch)
+
+    class _NoNotification:
+        cameranotification = _raising_property()
+
+    sw._device = _NoNotification()
+    sw.entity_description = SWITCH_TYPES["camera360_notification"]
+    assert sw.is_on is None
+
+
+def test_camera360_notification_none_turn_on_does_not_raise():
+    """turn_on for camera360_notification must not raise when service is absent."""
+    sw = SHCSwitch.__new__(SHCSwitch)
+
+    class _NoNotification:
+        cameranotification = _raising_property()
+
+    sw._device = _NoNotification()
+    sw.entity_description = SWITCH_TYPES["camera360_notification"]
+    sw.entity_id = "switch.cam360_notif"
+    sw.turn_on()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Issue #246 — silent_mode on_value / mapping verification
+# ---------------------------------------------------------------------------
+
+
+def test_silent_mode_on_value_is_mode_silent_enum():
+    """on_value for silent_mode must be the MODE_SILENT enum member."""
+    desc = SWITCH_TYPES["silent_mode"]
+    assert desc.on_key == "silentmode"
+    assert desc.on_value is SHCThermostat.SilentModeService.State.MODE_SILENT
+
+
+def test_silent_mode_is_on_true_when_mode_silent():
+    """is_on returns True when device.silentmode == MODE_SILENT."""
+    State = SHCThermostat.SilentModeService.State
+    sw = _make_switch(SWITCH_TYPES["silent_mode"], silentmode=State.MODE_SILENT)
+    assert sw.is_on is True
+
+
+def test_silent_mode_is_on_false_when_mode_normal():
+    """is_on returns False when device.silentmode == MODE_NORMAL."""
+    State = SHCThermostat.SilentModeService.State
+    sw = _make_switch(SWITCH_TYPES["silent_mode"], silentmode=State.MODE_NORMAL)
+    assert sw.is_on is False


### PR DESCRIPTION
Collected bug-fix + tightening batch, plus two device features. ~270 unit tests.

Closes #191, #185, #206, #273, #192.
Supersedes #308 (Heating Circuit) and #304 (cooling) — both integrated here.

- smoke detectors no longer report smoke on an intrusion alarm (#191)
- relay with no load / camera_360 switches no longer crash (#185, #206)
- setting temperature in boost no longer surfaces an HTTP 400 (#273)
- no phantom button events from Universal Switch II on battery updates (#192)
- light brightness None-guard + HS color priority; alarm ALARM_MUTED→triggered + bitwise features; number value clamping
- Heating Circuit climate entity (#308) + cooling HVACMode.COOL (#304)
- async phase 0: await scenario.trigger
- requires boschshcpy 0.2.113