### PR TITLE
0.4.106: smokedetector service target + Platform.VALVE guard

### DIFF
--- a/custom_components/bosch_shc/__init__.py
+++ b/custom_components/bosch_shc/__init__.py
@@ -69,8 +69,9 @@ PLATFORMS = [
     Platform.ALARM_CONTROL_PANEL,
     Platform.LIGHT,
     Platform.NUMBER,
-    Platform.VALVE,
 ]
+if hasattr(Platform, "VALVE"):
+    PLATFORMS.append(Platform.VALVE)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/bosch_shc/services.yaml
+++ b/custom_components/bosch_shc/services.yaml
@@ -1,10 +1,8 @@
 smokedetector_check:
-  fields:
-    entity_id:
-      example: "binary_sensor.smokedetector_living_room"
-      required: true
-      selector:
-        text:
+  target:
+    entity:
+      integration: bosch_shc
+      domain: binary_sensor
 
 trigger_scenario:
   fields:
@@ -42,12 +40,11 @@ trigger_rawscan:
 
 
 smokedetector_alarmstate:
+  target:
+    entity:
+      integration: bosch_shc
+      domain: binary_sensor
   fields:
-    entity_id:
-      example: "binary_sensor.smokedetector_living_room"
-      required: true
-      selector:
-        text:
     command:
       example: "CUSTOM_COMMAND"
       required: true

--- a/tests/bosch_shc/test_platforms_valve_guard.py
+++ b/tests/bosch_shc/test_platforms_valve_guard.py
@@ -1,0 +1,108 @@
+"""Regression test for Fix #169: Platform.VALVE must be guarded with hasattr().
+
+On older HA versions that pre-date the VALVE platform, Platform.VALVE does not
+exist. The module-level PLATFORMS list must only include it when available.
+"""
+
+import importlib
+import types
+
+import pytest
+
+
+def test_platforms_includes_valve_when_available():
+    """Platform.VALVE present -> included in PLATFORMS."""
+    from homeassistant.const import Platform
+
+    if not hasattr(Platform, "VALVE"):
+        pytest.skip("This HA version does not have Platform.VALVE")
+
+    import custom_components.bosch_shc.__init__ as init_mod
+
+    importlib.reload(init_mod)
+    assert Platform.VALVE in init_mod.PLATFORMS, (
+        "Platform.VALVE should be in PLATFORMS when available"
+    )
+
+
+def test_platforms_excludes_valve_when_missing():
+    """If Platform has no VALVE attribute, PLATFORMS must not contain it."""
+    from homeassistant.const import Platform
+
+    # Build a fake Platform namespace without VALVE to simulate older HA
+    fake_platform = types.SimpleNamespace(
+        BINARY_SENSOR=Platform.BINARY_SENSOR,
+        BUTTON=Platform.BUTTON,
+        COVER=Platform.COVER,
+        EVENT=Platform.EVENT,
+        SENSOR=Platform.SENSOR,
+        SWITCH=Platform.SWITCH,
+        CLIMATE=Platform.CLIMATE,
+        ALARM_CONTROL_PANEL=Platform.ALARM_CONTROL_PANEL,
+        LIGHT=Platform.LIGHT,
+        NUMBER=Platform.NUMBER,
+        # VALVE intentionally omitted
+    )
+
+    # Replicate the guarded PLATFORMS construction from __init__.py
+    platforms = [
+        fake_platform.BINARY_SENSOR,
+        fake_platform.BUTTON,
+        fake_platform.COVER,
+        fake_platform.EVENT,
+        fake_platform.SENSOR,
+        fake_platform.SWITCH,
+        fake_platform.CLIMATE,
+        fake_platform.ALARM_CONTROL_PANEL,
+        fake_platform.LIGHT,
+        fake_platform.NUMBER,
+    ]
+    if hasattr(fake_platform, "VALVE"):
+        platforms.append(fake_platform.VALVE)
+
+    assert Platform.VALVE not in platforms, (
+        "PLATFORMS must not contain Platform.VALVE when Platform has no VALVE attribute"
+    )
+
+
+def test_platforms_includes_all_base_platforms():
+    """All non-optional platforms are always present regardless of VALVE availability."""
+    from homeassistant.const import Platform
+
+    import custom_components.bosch_shc.__init__ as init_mod
+
+    importlib.reload(init_mod)
+
+    required = [
+        Platform.BINARY_SENSOR,
+        Platform.BUTTON,
+        Platform.COVER,
+        Platform.EVENT,
+        Platform.SENSOR,
+        Platform.SWITCH,
+        Platform.CLIMATE,
+        Platform.ALARM_CONTROL_PANEL,
+        Platform.LIGHT,
+        Platform.NUMBER,
+    ]
+    for platform in required:
+        assert platform in init_mod.PLATFORMS, (
+            f"{platform} must always be in PLATFORMS"
+        )
+
+
+def test_platforms_valve_guard_is_hasattr():
+    """Verify the guard pattern: hasattr(Platform, 'VALVE') -> append, else skip."""
+    # Test the guard logic itself with a known-present attribute
+    present_ns = types.SimpleNamespace(PRESENT=True)
+    missing_ns = types.SimpleNamespace()
+
+    result_present = []
+    if hasattr(present_ns, "PRESENT"):
+        result_present.append("PRESENT")
+    assert "PRESENT" in result_present
+
+    result_missing = []
+    if hasattr(missing_ns, "ABSENT"):
+        result_missing.append("ABSENT")
+    assert "ABSENT" not in result_missing

--- a/tests/bosch_shc/test_smokedetector_service_target.py
+++ b/tests/bosch_shc/test_smokedetector_service_target.py
@@ -1,0 +1,81 @@
+"""Regression test for Fix #43: smokedetector services must use target: not entity_id field.
+
+Entity services registered via platform.async_register_entity_service() receive
+their target entity through target.entity_id, not via service data. The services.yaml
+must declare target: with an entity selector (not a fields.entity_id text field).
+"""
+
+import pathlib
+import yaml
+
+
+SERVICES_YAML = (
+    pathlib.Path(__file__).parent.parent.parent
+    / "custom_components/bosch_shc/services.yaml"
+)
+
+
+def _load_services():
+    with open(SERVICES_YAML) as fh:
+        return yaml.safe_load(fh)
+
+
+def test_smokedetector_check_has_target():
+    """smokedetector_check declares target: (entity picker, not data field)."""
+    services = _load_services()
+    assert "target" in services["smokedetector_check"], (
+        "smokedetector_check must declare target: for entity targeting"
+    )
+
+
+def test_smokedetector_check_has_no_entity_id_field():
+    """smokedetector_check must NOT have fields.entity_id (would be a spurious text box)."""
+    services = _load_services()
+    fields = services["smokedetector_check"].get("fields") or {}
+    assert "entity_id" not in fields, (
+        "smokedetector_check.fields.entity_id must be removed; "
+        "entity targeting goes through target:, not service data"
+    )
+
+
+def test_smokedetector_alarmstate_has_target():
+    """smokedetector_alarmstate declares target: (entity picker)."""
+    services = _load_services()
+    assert "target" in services["smokedetector_alarmstate"], (
+        "smokedetector_alarmstate must declare target: for entity targeting"
+    )
+
+
+def test_smokedetector_alarmstate_has_no_entity_id_field():
+    """smokedetector_alarmstate must NOT have fields.entity_id."""
+    services = _load_services()
+    fields = services["smokedetector_alarmstate"].get("fields") or {}
+    assert "entity_id" not in fields, (
+        "smokedetector_alarmstate.fields.entity_id must be removed; "
+        "entity targeting goes through target:, not service data"
+    )
+
+
+def test_smokedetector_alarmstate_keeps_command_field():
+    """smokedetector_alarmstate still has fields.command (the real service parameter)."""
+    services = _load_services()
+    fields = services["smokedetector_alarmstate"].get("fields") or {}
+    assert "command" in fields, (
+        "smokedetector_alarmstate.fields.command must remain (it is the actual service parameter)"
+    )
+
+
+def test_smokedetector_check_target_scoped_to_integration():
+    """smokedetector_check target entity selector is scoped to bosch_shc integration."""
+    services = _load_services()
+    target = services["smokedetector_check"]["target"]
+    assert "entity" in target
+    assert target["entity"].get("integration") == "bosch_shc"
+
+
+def test_smokedetector_alarmstate_target_scoped_to_integration():
+    """smokedetector_alarmstate target entity selector is scoped to bosch_shc integration."""
+    services = _load_services()
+    target = services["smokedetector_alarmstate"]["target"]
+    assert "entity" in target
+    assert target["entity"].get("integration") == "bosch_shc"


### PR DESCRIPTION
Closes #43, #169.

- services.yaml: smokedetector_check/alarmstate use target:entity instead of a bogus required entity_id field (#43).
- __init__.py: Platform.VALVE added only when the enum has it, so older HA does not ImportError (#169).