### PR TITLE
Add Twinguard smoke alarm binary sensors

### DIFF
--- a/custom_components/bosch_shc/binary_sensor.py
+++ b/custom_components/bosch_shc/binary_sensor.py
@@ -1,6 +1,10 @@
 """Platform for binarysensor integration."""
 
+from __future__ import annotations
+
+import json
 from datetime import datetime, timedelta, timezone
+from typing import Callable
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
@@ -55,6 +59,8 @@ async def async_setup_entry(
     """Set up the SHC binary sensor platform."""
     entities = []
     session: SHCSession = hass.data[DOMAIN][config_entry.entry_id][DATA_SESSION]
+    smoke_detection_system = session.device_helper.smoke_detection_system
+    twinguard_alarm_tracker = None
 
     @callback
     def async_add_shuttercontact(
@@ -128,15 +134,30 @@ async def async_setup_entry(
             )
         )
 
-    binary_sensor = session.device_helper.smoke_detection_system
-    if binary_sensor:
+    if smoke_detection_system:
+        twinguard_alarm_tracker = TwinguardAlarmTracker(
+            hass=hass,
+            session=session,
+            smoke_detection_system=smoke_detection_system,
+        )
         entities.append(
             SmokeDetectionSystemSensor(
-                device=binary_sensor,
+                device=smoke_detection_system,
                 hass=hass,
                 entry_id=config_entry.entry_id,
             )
         )
+
+    if twinguard_alarm_tracker:
+        for binary_sensor in session.device_helper.twinguards:
+            entities.append(
+                TwinguardSmokeAlarmSensor(
+                    device=binary_sensor,
+                    hass=hass,
+                    entry_id=config_entry.entry_id,
+                    tracker=twinguard_alarm_tracker,
+                )
+            )
 
     for binary_sensor in session.device_helper.water_leakage_detectors:
         await async_migrate_to_new_unique_id(
@@ -428,6 +449,201 @@ class SmokeDetectorSensor(SHCEntity, BinarySensorEntity):
         return {
             "smokedetectorcheck_state": check_state,
             "alarmstate": alarm_state,
+        }
+
+
+class TwinguardAlarmTracker:
+    """Track active smoke alarms for Twinguard devices via the SHC system alarm."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        session: SHCSession,
+        smoke_detection_system: SHCSmokeDetectionSystem,
+    ) -> None:
+        """Initialize the tracker."""
+        self._hass = hass
+        self._session = session
+        self._smoke_detection_system = smoke_detection_system
+        self._service = None
+        self._listeners: list[Callable[[], None]] = []
+        self._active_trigger_ids: set[str] = set()
+        self._last_alarm_state: str | None = None
+
+        for service in self._smoke_detection_system.device_services:
+            if service.id == "SurveillanceAlarm":
+                self._service = service
+                self._service.subscribe_callback(
+                    self._smoke_detection_system.id + "_twinguard_alarm_listener",
+                    self._handle_alarm_update,
+                )
+                break
+
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self._handle_ha_stop)
+        self.refresh()
+
+    @property
+    def alarm_state(self) -> str | None:
+        """Return the global smoke detection alarm state."""
+        try:
+            return self._smoke_detection_system.alarm.name
+        except ValueError as err:
+            LOGGER.warning(
+                "Unknown smoke detection system alarm state for %s: %s",
+                self._smoke_detection_system.name,
+                err,
+            )
+            return None
+
+    def register_listener(self, listener: Callable[[], None]) -> None:
+        """Register a listener."""
+        self._listeners.append(listener)
+
+    def unregister_listener(self, listener: Callable[[], None]) -> None:
+        """Unregister a listener."""
+        try:
+            self._listeners.remove(listener)
+        except ValueError:
+            pass
+
+    def is_alarm_active_for(self, device_id: str) -> bool:
+        """Return whether a smoke alarm is active for the given Twinguard."""
+        return device_id in self._active_trigger_ids
+
+    def refresh(self) -> None:
+        """Refresh active trigger ids from the SHC."""
+        alarm_state = self.alarm_state
+        if alarm_state == SHCSmokeDetectionSystem.SurveillanceAlarmService.State.ALARM_OFF.name:
+            new_trigger_ids: set[str] = set()
+        else:
+            new_trigger_ids = self._extract_trigger_ids_from_messages()
+
+        if (
+            new_trigger_ids == self._active_trigger_ids
+            and alarm_state == self._last_alarm_state
+        ):
+            return
+
+        self._active_trigger_ids = new_trigger_ids
+        self._last_alarm_state = alarm_state
+        self._notify_listeners()
+
+    def _handle_alarm_update(self) -> None:
+        """Handle a surveillance alarm update from boschshcpy."""
+        self.refresh()
+
+    def _extract_trigger_ids_from_messages(self) -> set[str]:
+        """Extract active trigger ids from SMOKE_ALARM messages."""
+        try:
+            messages = self._session.api.get_messages()
+        except Exception as err:  # pylint: disable=broad-except
+            LOGGER.warning("Unable to fetch Bosch SHC messages: %s", err)
+            return self._active_trigger_ids
+
+        trigger_ids: set[str] = set()
+        for message in messages:
+            message_code = message.get("messageCode", {})
+            if message_code.get("name") != "SMOKE_ALARM":
+                continue
+            if message.get("sourceId") != self._smoke_detection_system.id:
+                continue
+
+            events = self._parse_surveillance_events(
+                message.get("arguments", {}).get("surveillanceEvents")
+            )
+            if any(event.get("type") == "ALARM_OFF" for event in events):
+                continue
+
+            for event in events:
+                trigger_id = event.get("triggerId")
+                if trigger_id:
+                    trigger_ids.add(trigger_id)
+
+        return trigger_ids
+
+    @staticmethod
+    def _parse_surveillance_events(raw_events) -> list[dict]:
+        """Parse surveillance events from a Bosch message payload."""
+        if isinstance(raw_events, list):
+            return [event for event in raw_events if isinstance(event, dict)]
+        if not raw_events:
+            return []
+
+        try:
+            parsed = json.loads(raw_events)
+        except (TypeError, json.JSONDecodeError):
+            return []
+
+        if not isinstance(parsed, list):
+            return []
+        return [event for event in parsed if isinstance(event, dict)]
+
+    def _notify_listeners(self) -> None:
+        """Notify registered listeners."""
+        for listener in list(self._listeners):
+            if hasattr(self._hass, "loop"):
+                self._hass.loop.call_soon_threadsafe(listener)
+            else:
+                listener()
+
+    @callback
+    def _handle_ha_stop(self, _) -> None:
+        """Handle Home Assistant stopping."""
+        if self._service is not None:
+            self._service.unsubscribe_callback(
+                self._smoke_detection_system.id + "_twinguard_alarm_listener"
+            )
+
+
+class TwinguardSmokeAlarmSensor(SHCEntity, BinarySensorEntity):
+    """Representation of a per-Twinguard smoke alarm sensor."""
+
+    _attr_device_class = BinarySensorDeviceClass.SMOKE
+
+    def __init__(
+        self,
+        device: SHCDevice,
+        hass: HomeAssistant,
+        entry_id: str,
+        tracker: TwinguardAlarmTracker,
+    ) -> None:
+        """Initialize the Twinguard smoke alarm sensor."""
+        self._hass = hass
+        self._tracker = tracker
+        self._tracker_listener = self._handle_tracker_update
+        super().__init__(device=device, entry_id=entry_id)
+
+    async def async_added_to_hass(self):
+        """Register tracker listener when entity is added."""
+        await super().async_added_to_hass()
+        self._tracker.register_listener(self._tracker_listener)
+
+    async def async_will_remove_from_hass(self):
+        """Unregister tracker listener when entity is removed."""
+        self._tracker.unregister_listener(self._tracker_listener)
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _handle_tracker_update(self) -> None:
+        """Handle tracker updates."""
+        self.schedule_update_ha_state()
+
+    @property
+    def is_on(self):
+        """Return the state of the sensor."""
+        return self._tracker.is_alarm_active_for(self._device.id)
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        return "mdi:smoke-detector"
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            "alarm_state": self._tracker.alarm_state,
+            "trigger_id": self._device.id,
         }
 
 

--- a/tests/bosch_shc/test_binary_sensor_setup.py
+++ b/tests/bosch_shc/test_binary_sensor_setup.py
@@ -35,6 +35,8 @@ from custom_components.bosch_shc.binary_sensor import (
     ShutterContactVibrationSensor,
     SmokeDetectionSystemSensor,
     SmokeDetectorSensor,
+    TwinguardAlarmTracker,
+    TwinguardSmokeAlarmSensor,
     WaterLeakageDetectorSensor,
     async_setup_entry,
 )
@@ -89,9 +91,11 @@ def _make_hass():
         async_listen_once=lambda event, cb: None,
         fire=lambda *args, **kwargs: None,
     )
+    loop = SimpleNamespace(call_soon_threadsafe=lambda cb, *args: cb(*args))
     hass = SimpleNamespace(
         bus=bus,
         data={},
+        loop=loop,
     )
     return hass
 
@@ -109,6 +113,7 @@ def _make_fake_session(
     universal_switches=None,
     wallthermostats=None,
     roomthermostats=None,
+    messages=None,
 ):
     """Build a fake session with device_helper and _subscribers."""
     session = SimpleNamespace()
@@ -118,6 +123,7 @@ def _make_fake_session(
         session._subscribers.append(cb_tuple)
 
     session.subscribe = _subscribe
+    session.api = SimpleNamespace(get_messages=lambda: messages or [])
 
     session.device_helper = SimpleNamespace(
         shutter_contacts=shutter_contacts or [],
@@ -340,6 +346,15 @@ class TestAsyncSetupEntry:
         session = _make_fake_session(smoke_detection_system=dev)
         self._setup(session)
         assert any("_eventlistener" in k for k in cb_store)
+
+    def test_twinguard_smoke_alarm_added_when_smoke_system_exists(self):
+        surv_svc = _make_service("SurveillanceAlarm")
+        sds = _make_base_device("sds-tw", device_services=[surv_svc])
+        sds.alarm = SHCSmokeDetectionSystem.SurveillanceAlarmService.State.ALARM_OFF
+        tw = _make_base_device("tw1", name="TW1")
+        session = _make_fake_session(smoke_detection_system=sds, twinguards=[tw])
+        entities, _ = self._setup(session)
+        assert any(isinstance(e, TwinguardSmokeAlarmSensor) for e in entities)
 
     # -- water leakage --
     def test_water_leakage_detector_added(self):
@@ -767,3 +782,80 @@ class TestSmokeDetectionSystemSensorInit:
         sensor = SmokeDetectionSystemSensor(device=dev, hass=hass, entry_id="E1")
         sensor._handle_ha_stop(None)
         assert "sds-stop_eventlistener" in unsub_store
+
+
+class TestTwinguardAlarmTracker:
+    def test_parse_surveillance_events_string(self):
+        raw = '[{"type":"SMOKE_LIGHT","triggerId":"tw1"},{"type":"ALARM_OFF"}]'
+        assert TwinguardAlarmTracker._parse_surveillance_events(raw) == [
+            {"type": "SMOKE_LIGHT", "triggerId": "tw1"},
+            {"type": "ALARM_OFF"},
+        ]
+
+    def test_active_trigger_ids_loaded_from_smoke_alarm_messages(self):
+        surv_svc = _make_service("SurveillanceAlarm")
+        sds = _make_base_device("smokeDetectionSystem", device_services=[surv_svc])
+        sds.alarm = SHCSmokeDetectionSystem.SurveillanceAlarmService.State.ALARM_ON
+        session = _make_fake_session(
+            smoke_detection_system=sds,
+            messages=[
+                {
+                    "messageCode": {"name": "SMOKE_ALARM"},
+                    "sourceId": "smokeDetectionSystem",
+                    "arguments": {
+                        "surveillanceEvents": '[{"type":"SMOKE_LIGHT","triggerId":"tw1"}]'
+                    },
+                }
+            ],
+        )
+        tracker = TwinguardAlarmTracker(_make_hass(), session, sds)
+        assert tracker.is_alarm_active_for("tw1") is True
+        assert tracker.is_alarm_active_for("tw2") is False
+
+    def test_alarm_off_clears_trigger_ids(self):
+        surv_svc = _make_service("SurveillanceAlarm")
+        sds = _make_base_device("smokeDetectionSystem", device_services=[surv_svc])
+        sds.alarm = SHCSmokeDetectionSystem.SurveillanceAlarmService.State.ALARM_ON
+        session = _make_fake_session(
+            smoke_detection_system=sds,
+            messages=[
+                {
+                    "messageCode": {"name": "SMOKE_ALARM"},
+                    "sourceId": "smokeDetectionSystem",
+                    "arguments": {
+                        "surveillanceEvents": '[{"type":"SMOKE_LIGHT","triggerId":"tw1"}]'
+                    },
+                }
+            ],
+        )
+        tracker = TwinguardAlarmTracker(_make_hass(), session, sds)
+        assert tracker.is_alarm_active_for("tw1") is True
+
+        sds.alarm = SHCSmokeDetectionSystem.SurveillanceAlarmService.State.ALARM_OFF
+        tracker.refresh()
+        assert tracker.is_alarm_active_for("tw1") is False
+
+    def test_alarm_state_change_notifies_even_with_same_trigger_ids(self):
+        surv_svc = _make_service("SurveillanceAlarm")
+        sds = _make_base_device("smokeDetectionSystem", device_services=[surv_svc])
+        sds.alarm = SHCSmokeDetectionSystem.SurveillanceAlarmService.State.ALARM_ON
+        session = _make_fake_session(
+            smoke_detection_system=sds,
+            messages=[
+                {
+                    "messageCode": {"name": "SMOKE_ALARM"},
+                    "sourceId": "smokeDetectionSystem",
+                    "arguments": {
+                        "surveillanceEvents": '[{"type":"SMOKE_LIGHT","triggerId":"tw1"}]'
+                    },
+                }
+            ],
+        )
+        tracker = TwinguardAlarmTracker(_make_hass(), session, sds)
+        listener = MagicMock()
+        tracker.register_listener(listener)
+
+        sds.alarm = SHCSmokeDetectionSystem.SurveillanceAlarmService.State.ALARM_MUTED
+        tracker.refresh()
+
+        listener.assert_called_once()


### PR DESCRIPTION
## What changed
- add per-Twinguard smoke `binary_sensor` entities when a Bosch smoke detection system is present
- derive active Twinguard alarms from `SMOKE_ALARM` messages emitted by the shared `smokeDetectionSystem`
- add tests for tracker parsing, trigger ID extraction, reset on `ALARM_OFF`, and entity setup

## Why
Twinguard devices do not expose the same local `Alarm` service as classic Bosch smoke detectors, so Home Assistant was not creating smoke alarm binary sensors for them. The SHC still exposes the relevant smoke alarm information through the shared smoke detection system plus the message history, which lets us map an active alarm back to the triggering Twinguard.

## Impact
Twinguard devices now appear as smoke alarm binary sensors and switch on only for the devices whose IDs are present in the active smoke alarm events.

## Validation
- `python3 -m py_compile custom_components/bosch_shc/binary_sensor.py tests/bosch_shc/test_binary_sensor_setup.py`
- added focused unit tests in `tests/bosch_shc/test_binary_sensor_setup.py`
- full `pytest` run was not possible in the local environment because `pytest` is not installed
