### PR TITLE
Add Twinguard smoke test support

### DIFF
--- a/custom_components/bosch_shc/binary_sensor.py
+++ b/custom_components/bosch_shc/binary_sensor.py
@@ -725,9 +725,7 @@ class TwinguardAlarmTracker:
         immediately (M1 fix — prevents up-to-30s stall on get_messages()).
         """
         self._hass.loop.call_soon_threadsafe(
-            lambda: self._hass.async_create_task(
-                self._hass.async_add_executor_job(self.refresh)
-            )
+            lambda: self._hass.async_add_executor_job(self.refresh)
         )
 
     def _extract_trigger_ids_from_messages(self) -> set[str]:
@@ -839,6 +837,11 @@ class TwinguardSmokeAlarmSensor(SHCEntity, BinarySensorEntity):
     def icon(self) -> str:
         """Return the icon of the sensor."""
         return "mdi:smoke-detector"
+
+    async def async_request_smoketest(self) -> None:
+        """Request a Twinguard smoke test."""
+        LOGGER.debug("Requesting smoke test on entity %s", self.name)
+        await self.hass.async_add_executor_job(self._device.smoketest_requested)
 
     @property
     def extra_state_attributes(self) -> dict:

--- a/custom_components/bosch_shc/button.py
+++ b/custom_components/bosch_shc/button.py
@@ -33,11 +33,31 @@ async def async_setup_entry(
     entities = []
     session: SHCSession = hass.data[DOMAIN][config_entry.entry_id][DATA_SESSION]
 
-    for button in session.device_helper.micromodule_impulse_relays:
+    for button in getattr(session.device_helper, "micromodule_impulse_relays", []):
         if device_excluded(button, config_entry.options):
             continue
         entities.append(
             SHCRelayButton(
+                device=button,
+                entry_id=config_entry.entry_id,
+            )
+        )
+
+    for button in getattr(session.device_helper, "smoke_detectors", []):
+        if device_excluded(button, config_entry.options):
+            continue
+        entities.append(
+            SHCSmokeTestButton(
+                device=button,
+                entry_id=config_entry.entry_id,
+            )
+        )
+
+    for button in getattr(session.device_helper, "twinguards", []):
+        if device_excluded(button, config_entry.options):
+            continue
+        entities.append(
+            SHCSmokeTestButton(
                 device=button,
                 entry_id=config_entry.entry_id,
             )
@@ -85,6 +105,22 @@ class SHCRelayButton(SHCEntity, ButtonEntity):
     def press(self) -> None:
         """Triggers impulse."""
         self._device.trigger_impulse_state()
+
+
+class SHCSmokeTestButton(SHCEntity, ButtonEntity):
+    """Button entity that requests a smoke detector self-test."""
+
+    _attr_icon = "mdi:smoke-detector-alert"
+
+    def __init__(self, device: SHCDevice, entry_id: str) -> None:
+        """Initialize the smoke-test button."""
+        super().__init__(device, entry_id)
+        self._attr_name = "Smoke Test"
+        self._attr_unique_id = f"{device.root_device_id}_{device.id}_smoke_test"
+
+    def press(self) -> None:
+        """Trigger the device self-test."""
+        self._device.smoketest_requested()
 
 
 class SHCScenarioButton(ButtonEntity):

--- a/tests/bosch_shc/test_binary_sensor_setup.py
+++ b/tests/bosch_shc/test_binary_sensor_setup.py
@@ -88,9 +88,9 @@ def _make_base_device(device_id="dev1", name="FakeDev", root_device_id="root1",
 def _make_hass():
     """Return a fake hass with bus.async_listen_once that records calls.
 
-    async_create_task and async_add_executor_job execute their callables
-    synchronously in tests so that _handle_alarm_update dispatch can be
-    verified without a real event loop.
+    async_add_executor_job executes its callables synchronously in tests so
+    that _handle_alarm_update dispatch can be verified without a real event
+    loop.
     call_soon_threadsafe also executes the callback immediately.
     """
     unsub_store = {}
@@ -114,18 +114,6 @@ def _make_hass():
     async def _async_add_executor_job(fn, *args):
         return fn(*args)
 
-    # Synchronous task creation: drain the coroutine immediately so refresh()
-    # runs synchronously in unit tests (no real event loop needed).
-    def _async_create_task(coro):
-        import asyncio as _asyncio
-        try:
-            loop = _asyncio.get_running_loop()
-            # Already inside an event loop — schedule as a task (async tests).
-            loop.create_task(coro)
-        except RuntimeError:
-            # No running loop — run synchronously (direct unit-test calls).
-            _asyncio.run(coro)
-
     # call_soon_threadsafe executes the callback immediately in tests (synchronous)
     loop = SimpleNamespace(call_soon_threadsafe=lambda cb, *args: cb(*args))
     hass = SimpleNamespace(
@@ -133,7 +121,6 @@ def _make_hass():
         data={},
         loop=loop,
         async_add_executor_job=_async_add_executor_job,
-        async_create_task=_async_create_task,
     )
     return hass
 
@@ -1231,6 +1218,26 @@ class TestTwinguardAlarmTracker:
         assert len(dispatched) == 1
         assert callable(dispatched[0])
 
+    def test_handle_alarm_update_does_not_wrap_executor_future_in_task(self):
+        """Regression: async_add_executor_job may return a Future, not a coroutine."""
+        surv_svc = _make_service("SurveillanceAlarm")
+        sds = _make_base_device("sds-future", device_services=[surv_svc])
+        sds.alarm = SHCSmokeDetectionSystem.SurveillanceAlarmService.State.ALARM_OFF
+        session = _make_fake_session(smoke_detection_system=sds)
+        hass = _make_hass()
+
+        executor_calls = []
+
+        def _executor_job(fn, *args):
+            executor_calls.append((fn, args))
+            return object()  # stands in for HA Future-like return value
+
+        hass.async_add_executor_job = _executor_job
+        tracker = self._make_tracker(sds, session, hass=hass)
+        tracker._handle_alarm_update()
+
+        assert executor_calls == [(tracker.refresh, ())]
+
     # -- get_messages error handling --
 
     def test_extract_trigger_ids_handles_api_error_gracefully(self):
@@ -1404,6 +1411,21 @@ class TestTwinguardSmokeAlarmSensor:
         attrs = sensor.extra_state_attributes
         assert "alarm_state" in attrs
         assert attrs["alarm_state"] == "ALARM_OFF"
+
+    def test_async_request_smoketest(self):
+        jobs = []
+
+        async def _fake_executor(fn, *args):
+            jobs.append((fn, args))
+
+        sensor, _ = self._make_sensor("tw-smoketest")
+        sensor._device.smoketest_requested = MagicMock()
+        sensor.hass = _make_hass()
+        sensor.hass.async_add_executor_job = _fake_executor
+
+        asyncio.run(sensor.async_request_smoketest())
+
+        assert len(jobs) == 1
 
     def test_handle_tracker_update_calls_schedule_update(self):
         """_handle_tracker_update() calls schedule_update_ha_state()."""

--- a/tests/bosch_shc/test_binary_sensor_setup.py
+++ b/tests/bosch_shc/test_binary_sensor_setup.py
@@ -1194,10 +1194,10 @@ class TestTwinguardAlarmTracker:
                 }
             ],
         )
-        tracker = self._make_tracker(sds, session)
-
         called = []
         hass = _make_hass()
+        hass.async_add_executor_job = lambda fn, *args: fn(*args)
+        tracker = self._make_tracker(sds, session, hass=hass)
         tracker.register_listener(hass, lambda: called.append(1))
         tracker._handle_alarm_update()
         assert tracker.is_alarm_active_for("tw1") is True

--- a/tests/bosch_shc/test_button_unit.py
+++ b/tests/bosch_shc/test_button_unit.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from custom_components.bosch_shc.button import SHCRelayButton
+from custom_components.bosch_shc.button import SHCRelayButton, SHCSmokeTestButton
 from custom_components.bosch_shc.entity import SHCEntity
 from homeassistant.components.button import ButtonEntity
 
@@ -153,6 +153,46 @@ class TestPress:
         btn = _relay_via_init()
         btn._device.trigger_impulse_state = lambda: None
         assert btn.press() is None
+
+
+class TestSHCSmokeTestButton:
+    def _smoke_button_via_init(
+        self,
+        name: str = "TwinGuard 1",
+        device_id: str = "hdm:ZigBee:abc123",
+        root_device_id: str = "aa:bb:cc:00:00:99",
+    ) -> SHCSmokeTestButton:
+        dev = _fake_device(
+            name=name, device_id=device_id, root_device_id=root_device_id
+        )
+        dev.smoketest_requested = lambda: None
+        btn = SHCSmokeTestButton.__new__(SHCSmokeTestButton)
+        with patch.object(SHCSmokeTestButton, "_update_attr", lambda self: None):
+            SHCSmokeTestButton.__init__(btn, dev, "entry_test")
+        return btn
+
+    def test_attr_name(self):
+        btn = self._smoke_button_via_init()
+        assert btn._attr_name == "Smoke Test"
+
+    def test_unique_id(self):
+        btn = self._smoke_button_via_init(
+            device_id="hdm:ZigBee:dev1", root_device_id="root1"
+        )
+        assert btn._attr_unique_id == "root1_hdm:ZigBee:dev1_smoke_test"
+
+    def test_press_calls_smoketest_requested(self):
+        calls = []
+        btn = self._smoke_button_via_init()
+        btn._device.smoketest_requested = lambda: calls.append(True)
+        btn.press()
+        assert calls == [True]
+
+    def test_is_button_entity(self):
+        assert issubclass(SHCSmokeTestButton, ButtonEntity)
+
+    def test_is_shc_entity(self):
+        assert issubclass(SHCSmokeTestButton, SHCEntity)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/bosch_shc/test_platforms_setup.py
+++ b/tests/bosch_shc/test_platforms_setup.py
@@ -21,7 +21,7 @@ from unittest.mock import AsyncMock, patch
 
 from boschshcpy import SHCShutterControl
 
-from custom_components.bosch_shc.button import SHCRelayButton
+from custom_components.bosch_shc.button import SHCRelayButton, SHCSmokeTestButton
 from custom_components.bosch_shc.const import DATA_SESSION, DOMAIN
 from custom_components.bosch_shc.cover import BlindsControlCover, ShutterControlCover
 from custom_components.bosch_shc.light import LightSwitch
@@ -173,6 +173,27 @@ def _button_device() -> SimpleNamespace:
         device_model="MR",
         status="AVAILABLE",
         deleted=False,
+    )
+
+
+def _smoke_test_device(
+    name: str = "Test Rauchmelder",
+    device_id: str = "hdm:ZigBee:smoke1",
+    root_device_id: str = "aa:bb:cc:00:00:07",
+) -> SimpleNamespace:
+    """Minimal device for SHCSmokeTestButton.__init__."""
+    return SimpleNamespace(
+        name=name,
+        id=device_id,
+        root_device_id=root_device_id,
+        serial=f"serial-{device_id}",
+        device_services=[],
+        manufacturer="Bosch",
+        device_model="SMOKE",
+        status="AVAILABLE",
+        deleted=False,
+        room_id=None,
+        smoketest_requested=lambda: None,
     )
 
 
@@ -659,7 +680,7 @@ class TestValveSetupEntry:
 # ---------------------------------------------------------------------------
 
 class TestButtonSetupEntry:
-    """Button async_setup_entry: micromodule_impulse_relays → SHCRelayButton."""
+    """Button async_setup_entry for relays and smoke-test buttons."""
 
     def _run(self, session: object) -> list:
         from custom_components.bosch_shc.button import async_setup_entry
@@ -725,7 +746,37 @@ class TestButtonSetupEntry:
     def test_entry_id_stored(self) -> None:
         dev = _button_device()
         session = SimpleNamespace(
-            device_helper=SimpleNamespace(micromodule_impulse_relays=[dev])
+            device_helper=SimpleNamespace(
+                micromodule_impulse_relays=[dev],
+                smoke_detectors=[],
+                twinguards=[],
+            )
         )
         result = self._run(session)
         assert result[0]._entry_id == "E1"
+
+    def test_smoke_detectors_produce_smoke_test_buttons(self) -> None:
+        dev = _smoke_test_device()
+        session = SimpleNamespace(
+            device_helper=SimpleNamespace(
+                micromodule_impulse_relays=[],
+                smoke_detectors=[dev],
+                twinguards=[],
+            )
+        )
+        result = self._run(session)
+        assert len(result) == 1
+        assert isinstance(result[0], SHCSmokeTestButton)
+
+    def test_twinguards_produce_smoke_test_buttons(self) -> None:
+        dev = _smoke_test_device(name="TwinGuard", device_id="hdm:ZigBee:tw1")
+        session = SimpleNamespace(
+            device_helper=SimpleNamespace(
+                micromodule_impulse_relays=[],
+                smoke_detectors=[],
+                twinguards=[dev],
+            )
+        )
+        result = self._run(session)
+        assert len(result) == 1
+        assert isinstance(result[0], SHCSmokeTestButton)


### PR DESCRIPTION
## What changed

- add a dedicated `Smoke Test` button entity for Bosch smoke detectors and TwinGuards
- allow the existing `smokedetector_check` entity service to work on TwinGuard smoke binary sensors as well
- harden the TwinGuard alarm refresh dispatch so it no longer wraps `async_add_executor_job(...)` in `async_create_task(...)`

## Why

TwinGuard smoke entities exposed the per-device smoke alarm state, but they were still missing the same smoke-test ergonomics that classic smoke detectors had.

On top of that, calling `bosch_shc.smokedetector_check` on a TwinGuard smoke entity failed because `TwinguardSmokeAlarmSensor` did not implement `async_request_smoketest()`. In some Home Assistant / Python combinations, the current alarm refresh dispatch also raised `TypeError: a coroutine was expected, got <Future ...>` because `async_add_executor_job(...)` may return a Future-like object instead of a coroutine.

## User impact

- TwinGuard smoke entities can now be targeted by `bosch_shc.smokedetector_check`
- every smoke detector and TwinGuard gets a dedicated `button` entity to trigger the smoke test directly from Home Assistant
- the TwinGuard alarm tracker no longer trips over Future-vs-coroutine behavior during live alarm updates

## Validation

- `python3 -m py_compile custom_components/bosch_shc/binary_sensor.py custom_components/bosch_shc/button.py tests/bosch_shc/test_binary_sensor_setup.py tests/bosch_shc/test_button_unit.py tests/bosch_shc/test_platforms_setup.py`
- verified live in Home Assistant that the new `button.*_smoke_test` entities are created for TwinGuards and Bosch smoke detectors
- verified live that a real TwinGuard smoke alarm still flips the per-device HA smoke sensor correctly
