### PR TITLE
Suggest the Bosch Camera Tool when cameras are present

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ It talks directly to the controller over mutual-TLS on your LAN — **no cloud, 
 | `switch` | Smart Plug, Smart Plug Compact, Light Control, Micromodule Relay, Camera Eyes / 360 / Outdoor Gen2 (privacy, light, notification), Presence Simulation, Bypass (Shutter Contact 2), Child Lock, Pet Immunity (Motion Detector), Silent Mode (thermostat), Vibration detection, User-Defined States |
 | `valve` | Thermostat radiator valve (position, diagnostic) |
 
+> [!TIP]
+> **Bosch cameras?** This integration exposes the basics (privacy / light / notification switches, stream). For a lot more — snapshots, motion / FCM push events, light control and richer streaming — use the dedicated companion project: **[Bosch Smart Home Camera Tool](https://github.com/mosandlt/Bosch-Smart-Home-Camera-Tool-HomeAssistant)**. The two run side by side. (When a camera is present, the integration also shows a one-time, dismissible suggestion pointing there.)
+
 ## Services / actions
 
 | Action | Description |

--- a/custom_components/bosch_shc/__init__.py
+++ b/custom_components/bosch_shc/__init__.py
@@ -41,6 +41,7 @@ from homeassistant.exceptions import (
 )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.event import (
     async_track_state_change_event,
     async_track_time_interval,
@@ -489,6 +490,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _register_rawscan_service(hass)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Tip (not a problem): the dedicated Bosch camera tool offers far more for
+    # the SHC cameras than this integration. Surface a single dismissible
+    # suggestion when at least one camera is present; remove it otherwise.
+    camera_count = (
+        len(session.device_helper.camera_eyes)
+        + len(session.device_helper.camera_360)
+        + len(session.device_helper.camera_outdoor_gen2)
+    )
+    if camera_count:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "camera_tool_available",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="camera_tool_available",
+            learn_more_url=(
+                "https://github.com/mosandlt/"
+                "Bosch-Smart-Home-Camera-Tool-HomeAssistant"
+            ),
+        )
+    else:
+        ir.async_delete_issue(hass, DOMAIN, "camera_tool_available")
 
     return True
 

--- a/custom_components/bosch_shc/config_flow.py
+++ b/custom_components/bosch_shc/config_flow.py
@@ -471,10 +471,16 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
         # Build device/room option lists from the live session.
         device_options = []
         room_options = []
+        _has_cameras = False
         try:
             data = self.hass.data.get(DOMAIN, {}).get(self.config_entry.entry_id)
             if data:
                 session = data[DATA_SESSION]
+                _has_cameras = bool(
+                    session.device_helper.camera_eyes
+                    or session.device_helper.camera_360
+                    or session.device_helper.camera_outdoor_gen2
+                )
                 rooms = {r.id: r.name for r in session.rooms}
                 for dev in session.devices:
                     room_name = rooms.get(getattr(dev, "room_id", None), "")
@@ -598,4 +604,15 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
                 ),
             }
         )
-        return self.async_show_form(step_id="init", data_schema=schema)
+        camera_note = (
+            "\n\n💡 You have Bosch cameras connected — for advanced camera "
+            "features beyond this integration, see the dedicated Camera Tool: "
+            "https://github.com/mosandlt/Bosch-Smart-Home-Camera-Tool-HomeAssistant"
+            if _has_cameras
+            else ""
+        )
+        return self.async_show_form(
+            step_id="init",
+            data_schema=schema,
+            description_placeholders={"camera_tool": camera_note},
+        )

--- a/custom_components/bosch_shc/strings.json
+++ b/custom_components/bosch_shc/strings.json
@@ -87,7 +87,7 @@
     "step": {
       "init": {
         "title": "Bosch SHC — Settings",
-        "description": "Configure which entities and automations the Bosch Smart Home Controller integration creates and manages.",
+        "description": "Configure which entities and automations the Bosch Smart Home Controller integration creates and manages. {camera_tool}",
         "sections": {
           "features": {
             "name": "Features",
@@ -219,6 +219,12 @@
           "description": "Command string to send to the smoke detector."
         }
       }
+    }
+  },
+  "issues": {
+    "camera_tool_available": {
+      "title": "More for your Bosch cameras",
+      "description": "Bosch cameras were detected. This integration covers the basics; the dedicated **Bosch Smart Home Camera Tool** does much more for them (snapshots, motion / FCM push, lights, streams). Open \"Learn more\" for the project, then dismiss this notice."
     }
   }
 }

--- a/custom_components/bosch_shc/translations/de.json
+++ b/custom_components/bosch_shc/translations/de.json
@@ -86,7 +86,7 @@
     "step": {
       "init": {
         "title": "Bosch SHC — Einstellungen",
-        "description": "Legt fest, welche Entitäten und Automationen die Bosch SHC Integration erstellt und verwaltet.",
+        "description": "Legt fest, welche Entitäten und Automationen die Bosch SHC Integration erstellt und verwaltet. {camera_tool}",
         "sections": {
           "features": {
             "name": "Features",
@@ -218,6 +218,12 @@
           "description": "Befehl, der an den Rauchmelder gesendet werden soll."
         }
       }
+    }
+  },
+  "issues": {
+    "camera_tool_available": {
+      "title": "Mehr für deine Bosch-Kameras",
+      "description": "Bosch-Kameras erkannt. Diese Integration deckt die Grundfunktionen ab; das dedizierte **Bosch Smart Home Camera Tool** kann für Kameras deutlich mehr (Snapshots, Bewegungs-/FCM-Push, Licht, Streams). Öffne \"Mehr erfahren\" für das Projekt und blende diesen Hinweis dann aus."
     }
   }
 }

--- a/custom_components/bosch_shc/translations/en.json
+++ b/custom_components/bosch_shc/translations/en.json
@@ -86,7 +86,7 @@
     "step": {
       "init": {
         "title": "Bosch SHC — Settings",
-        "description": "Configure which entities and automations the Bosch Smart Home Controller integration creates and manages.",
+        "description": "Configure which entities and automations the Bosch Smart Home Controller integration creates and manages. {camera_tool}",
         "sections": {
           "features": {
             "name": "Features",
@@ -218,6 +218,12 @@
           "description": "Command string to send to the smoke detector."
         }
       }
+    }
+  },
+  "issues": {
+    "camera_tool_available": {
+      "title": "More for your Bosch cameras",
+      "description": "Bosch cameras were detected. This integration covers the basics; the dedicated **Bosch Smart Home Camera Tool** does much more for them (snapshots, motion / FCM push, lights, streams). Open \"Learn more\" for the project, then dismiss this notice."
     }
   }
 }


### PR DESCRIPTION
## What
When the integration detects a Bosch camera (Eyes / 360 / Outdoor Gen2), point users to the dedicated companion project, which does much more for cameras than this integration (snapshots, motion / FCM push events, light control, richer streaming):
https://github.com/mosandlt/Bosch-Smart-Home-Camera-Tool-HomeAssistant

Three tasteful, non-blocking surfaces (all opt-out / dismissible):
1. **README** — a `> [!TIP]` under *Supported platforms*.
2. **Repair issue** — a dismissible suggestion (`is_fixable=False`, `learn_more_url`) created only when a camera is present, and removed when none are.
3. **Options dialog** — a one-line note when cameras are present (via `description_placeholders`).

Strings added for `en` + `de` (and source `strings.json`); other locales simply fall back / show no note.

## Notes / your call, @tschamm
- This is **promotional content for a sibling project**, in *your* integration — so I'm bringing it as a PR for you to accept or decline rather than pushing it. No hard feelings if you'd rather not, or want only the README bit.
- HA's `IssueSeverity` has no `INFO` level, so the repair shows at **`WARNING`** styling (⚠️). If that feels too alarming for a tip, say the word and I'll drop the repair surface and keep just the README (+ options note).
- Tests green (1700 unit), flake8 clean. Context: came up via #36 / camera questions.

No rush — happy to trim to whatever you're comfortable with.
