### PR TITLE
Add community health files (CoC, contributing, security, templates)

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/01-question.yml
+++ b/.github/DISCUSSION_TEMPLATE/01-question.yml
@@ -1,0 +1,59 @@
+title: "[Q&A] "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for posting! Fill in the fields below so we can help efficiently.
+  - type: input
+    id: integration_version
+    attributes:
+      label: Integration version (boschshc-hass)
+      description: "Found in HACS under the integration entry."
+      placeholder: "e.g. 0.4.108"
+    validations:
+      required: true
+  - type: input
+    id: ha_version
+    attributes:
+      label: Home Assistant version
+      description: "Found under Settings → About."
+      placeholder: "e.g. 2026.5.3"
+    validations:
+      required: true
+  - type: dropdown
+    id: shc_generation
+    attributes:
+      label: SHC generation
+      options:
+        - SHC 1
+        - SHC 2
+        - Unknown / not relevant
+    validations:
+      required: false
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: "What do you want to know? Describe what you tried and what happened."
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: HA logs (if relevant)
+      description: |
+        Paste relevant log lines — Bosch-related lines only, not the full log.
+        Enable debug logging first: Developer Tools → Services → logger.set_level.
+      render: shell
+    validations:
+      required: false
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have read the [README](https://github.com/tschamm/boschshc-hass#readme) and checked existing discussions
+          required: true
+        - label: This is not a bug report (bugs go to GitHub Issues)
+          required: true

--- a/.github/DISCUSSION_TEMPLATE/02-idea.yml
+++ b/.github/DISCUSSION_TEMPLATE/02-idea.yml
@@ -1,0 +1,53 @@
+title: "[Idea] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Got a feature idea? Describe it below so others can vote and comment.
+  - type: input
+    id: integration_version
+    attributes:
+      label: Integration version you are using
+      placeholder: "e.g. 0.4.108"
+    validations:
+      required: false
+  - type: dropdown
+    id: shc_generation
+    attributes:
+      label: Relevant SHC generation (if applicable)
+      options:
+        - SHC 1
+        - SHC 2
+        - Both / model-agnostic
+        - Not applicable
+    validations:
+      required: false
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: "What problem does this solve? What workflow would it enable?"
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: "Describe your idea. If you know the relevant Bosch API service, mention it."
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: "Any workarounds you already tried?"
+    validations:
+      required: false
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing Ideas discussions and did not find a duplicate
+          required: true

--- a/.github/DISCUSSION_TEMPLATE/03-show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/03-show-and-tell.yml
@@ -1,0 +1,60 @@
+title: "[Show & Tell] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Share your setup, dashboard, automation, or creative use of the integration!
+  - type: input
+    id: integration_version
+    attributes:
+      label: Integration version
+      placeholder: "e.g. 0.4.108"
+    validations:
+      required: true
+  - type: dropdown
+    id: shc_generation
+    attributes:
+      label: SHC generation(s) in your setup
+      options:
+        - SHC 1
+        - SHC 2
+        - Both
+      multiple: true
+    validations:
+      required: false
+  - type: dropdown
+    id: category
+    attributes:
+      label: What are you sharing?
+      options:
+        - Dashboard / Lovelace card
+        - Automation
+        - Script / Blueprint
+        - Node-RED flow
+        - Full smart home setup
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: "Describe what you built and why it is useful."
+    validations:
+      required: true
+  - type: textarea
+    id: code_config
+    attributes:
+      label: Config / code snippet (optional)
+      description: "Paste YAML, JSON, or code if you want to share the details."
+      render: yaml
+    validations:
+      required: false
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / links (optional)
+      description: "Drag & drop images or paste links."
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/04-general.yml
+++ b/.github/DISCUSSION_TEMPLATE/04-general.yml
@@ -1,0 +1,30 @@
+title: "[General] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for general discussions that don't fit Q&A, Ideas, or Show & Tell.
+  - type: input
+    id: integration_version
+    attributes:
+      label: Integration version (if relevant)
+      placeholder: "e.g. 0.4.108"
+    validations:
+      required: false
+  - type: textarea
+    id: topic
+    attributes:
+      label: Topic / discussion
+      description: "What would you like to discuss?"
+    validations:
+      required: true
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: This is not a bug report (bugs go to GitHub Issues)
+          required: true
+        - label: This is not a question (questions go to Q&A)
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,139 @@
+name: Bug Report
+description: Report a bug in the Bosch Smart Home Controller integration
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Before you submit
+
+        Collect debug data first — it saves follow-up round-trips:
+
+        1. **Enable debug logging** — HA Developer Tools → Services:
+           ```yaml
+           service: logger.set_level
+           data:
+             custom_components.bosch_shc: debug
+             boschshcpy: debug
+           ```
+           Or via the UI: **Settings → Devices & Services → Bosch Smart Home Controller → Enable debug logging**.
+
+        2. **Collect a rawscan** (for device-related bugs) — HA Developer Tools → Services:
+           ```yaml
+           service: bosch_shc.trigger_rawscan
+           ```
+           This writes a JSON dump of live SHC device state to the HA log.
+
+        3. **Reproduce the issue**, then copy the relevant log lines.
+
+        4. **Disable debug logging** again after collecting data.
+
+        **No real SHC serial numbers, passwords, or other credentials in reports.** Use redacted/placeholder values.
+
+  - type: input
+    id: ha_version
+    attributes:
+      label: Home Assistant version
+      placeholder: "e.g. 2026.5.3"
+    validations:
+      required: true
+
+  - type: input
+    id: integration_version
+    attributes:
+      label: Integration version (boschshc-hass)
+      description: Shown in HACS under the integration entry.
+      placeholder: "e.g. 0.4.108"
+    validations:
+      required: true
+
+  - type: input
+    id: lib_version
+    attributes:
+      label: boschshcpy version
+      description: Shown in HA Settings → System → Repairs → Logs, or run `pip show boschshcpy` in the HA container.
+      placeholder: "e.g. 0.2.116"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: shc_generation
+    attributes:
+      label: SHC generation
+      options:
+        - SHC 1
+        - SHC 2
+        - Unknown
+    validations:
+      required: true
+
+  - type: input
+    id: device_model
+    attributes:
+      label: Affected device model(s)
+      description: e.g. "Radiator Thermostat II", "Shutter Control II", "Smoke Detector II"
+      placeholder: "e.g. Radiator Thermostat II"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug. What did you expect instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Set thermostat target temperature to 22 °C
+        2. Temperature jumps back to 20 °C immediately
+        3. Check HA log — see error "..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Debug logs
+      description: |
+        Paste relevant log lines for `custom_components.bosch_shc` and `boschshcpy`.
+        Include timestamps. Enable debug logging first (see instructions above).
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: rawscan
+    attributes:
+      label: Rawscan output (for device bugs)
+      description: |
+        If the bug is device-related, paste the rawscan JSON output here.
+        Trigger via: Developer Tools → Services → `bosch_shc.trigger_rawscan`.
+        Redact any serial numbers or credentials before posting.
+      render: json
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Any other relevant information (SHC firmware, network setup, etc.).
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues and did not find a duplicate
+          required: true
+        - label: This report contains no real serial numbers, passwords, or credentials
+          required: true
+        - label: I have attached debug logs (and rawscan if device-related)
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Q&A / Questions
+    url: https://github.com/tschamm/boschshc-hass/discussions/categories/q-a
+    about: Ask how-to questions and get help from the community.
+  - name: Bosch SHC Local API Docs
+    url: https://github.com/BoschSmartHome/bosch-shc-api-docs
+    about: Official Bosch Smart Home Controller local REST API documentation.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,60 @@
+name: Feature Request
+description: Request support for a new device or feature
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to request support for a new Bosch SHC device or a new feature.
+        Check [existing issues](https://github.com/tschamm/boschshc-hass/issues) and [Discussions](https://github.com/tschamm/boschshc-hass/discussions) for duplicates first.
+
+  - type: input
+    id: device_or_feature
+    attributes:
+      label: Device or feature
+      description: Name the Bosch device model or the feature you want.
+      placeholder: "e.g. Bosch Smart Plug Compact (BSM 81XX), or: expose valve tappet as HA sensor"
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case
+      description: What would you do with it? What problem does it solve?
+    validations:
+      required: true
+
+  - type: input
+    id: bosch_service
+    attributes:
+      label: Bosch API service / rawscan (if known)
+      description: |
+        If you know the relevant Bosch SHC API service name (from the
+        [API docs](https://github.com/BoschSmartHome/bosch-shc-api-docs)), paste it here.
+        You can also attach a rawscan (Developer Tools → Services → `bosch_shc.trigger_rawscan`)
+        that includes the device.
+      placeholder: "e.g. PowerMeterService, SmokeSensationService"
+    validations:
+      required: false
+
+  - type: textarea
+    id: rawscan
+    attributes:
+      label: Rawscan excerpt (optional)
+      description: |
+        Paste the relevant device section from a rawscan if available.
+        Redact serial numbers and credentials before posting.
+      render: json
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and discussions for duplicates
+          required: true
+        - label: This request contains no real serial numbers or credentials
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## What and why
+
+<!-- Describe what this PR changes and why. -->
+
+## Related issue
+
+<!-- Reference the issue with bare #N or "Addresses #N".
+     NEVER use "Fixes", "Closes", or "Resolves" — GitHub auto-closes the issue on
+     merge/push before the reporter confirms the fix. -->
+
+Addresses #
+
+## Checklist
+
+- [ ] `scripts/local-ci.sh` passes locally
+- [ ] `flake8` is clean (`pipx run flake8 --max-line-length=88 --extend-ignore=E501,W503 <changed files>`)
+- [ ] Tests added or updated in `tests/bosch_shc/` for behavioral changes
+- [ ] If this requires a `boschshcpy` lib change: lib PR is opened/merged and `manifest.json` pin is bumped
+- [ ] No PII, no real SHC serial numbers, no credentials in commits or PR description

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,61 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community maintainers are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers (@tschamm). All complaints will be reviewed and
+investigated promptly and fairly. Maintainers are obligated to respect the
+privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing
+
+Thanks for taking the time to contribute to the Bosch Smart Home Controller integration!
+
+## Reporting issues
+
+- Use the [issue tracker](https://github.com/tschamm/boschshc-hass/issues) and pick the matching template.
+- Include HA version, integration version (from HACS), boschshcpy version, and SHC generation (SHC 1 or SHC 2).
+- For bugs, attach DEBUG-level logs for `custom_components.bosch_shc` and `boschshcpy`.
+- For device-related bugs, trigger a rawscan first (see below) and attach the output.
+- **No PII, no real SHC serial numbers, no credentials** in issues or PRs. Use redacted/placeholder values.
+
+### Enabling debug logging
+
+In HA Developer Tools → Services, call:
+
+```yaml
+service: logger.set_level
+data:
+  custom_components.bosch_shc: debug
+  boschshcpy: debug
+```
+
+Or use the UI: **Settings → Devices & Services → Bosch Smart Home Controller → Enable debug logging**.
+
+### Collecting a rawscan
+
+In HA Developer Tools → Services, call:
+
+```yaml
+service: bosch_shc.trigger_rawscan
+```
+
+This writes a JSON dump of the live SHC device state to the HA log. Attach the output to your issue.
+
+## Pull requests
+
+1. Fork the repo and create a focused feature branch.
+2. Keep changes focused — one logical change per PR.
+3. Reference the issue number in the PR body using bare `#N` or `Addresses #N`.
+   **Never use `Fixes`, `Closes`, or `Resolves` #N** — GitHub auto-closes the issue on merge/push before the reporter confirms the fix.
+4. Add or update tests in `tests/bosch_shc/` for behavioral changes.
+5. Run the local CI gate before opening the PR (see below).
+6. No PII, no real SHC serials, no credentials in commits or PR descriptions.
+
+### Fork-based PR flow
+
+```bash
+# Add the upstream and your fork as remotes
+git remote add upstream https://github.com/tschamm/boschshc-hass.git
+git remote add fork https://github.com/<your-user>/boschshc-hass.git
+
+# Create a branch from upstream master
+git fetch upstream
+git checkout -b my-fix upstream/master
+
+# ... make changes ...
+
+# Push to your fork and open a PR against tschamm/boschshc-hass master
+git push fork my-fix
+gh pr create --repo tschamm/boschshc-hass --base master --head <your-user>:my-fix
+```
+
+## Local CI gate
+
+Run before every push:
+
+```bash
+scripts/local-ci.sh [lib|hass|all]
+```
+
+This mirrors the GitHub Actions checks (compile, tests, lint, optional build). Get it green before opening a PR.
+
+## Linting
+
+`flake8` is the only enforced linter. Run it with:
+
+```bash
+pipx run flake8 --max-line-length=88 --extend-ignore=E501,W503 <files>
+```
+
+The repo `.flake8` already sets these options, so `pipx run flake8 <files>` also works. Pre-existing F401 warnings in `__init__.py`, `cover.py`, and `sensor.py` are not ours — do not fix unrelated lint in the same PR.
+
+## Running tests
+
+Unit tests under `tests/bosch_shc/` can be run locally without a full HA harness:
+
+```bash
+PYTHONPATH="<path-to-boschshc-hass>:<path-to-boschshcpy>" \
+  PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+  python3 -m pytest tests/bosch_shc/<file> -q -o addopts=""
+```
+
+Tests for `config_flow` and `device_trigger` require the full HA test harness — let upstream CI run those (they run on every PR via GitHub Actions).
+
+## Library changes
+
+If your fix requires a change to [boschshcpy](https://github.com/tschamm/boschshcpy):
+
+1. Open a PR against `tschamm/boschshcpy` first.
+2. Wait for a new PyPI release.
+3. Bump `requirements` in `custom_components/bosch_shc/manifest.json` to the new version.
+4. Reference both PRs in each other.
+
+## Releases
+
+Releases are cut by the maintainers. Do not bump `manifest.json` version or edit `CHANGELOG.md` in feature PRs — that is handled as part of the release.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest released version of `bosch_shc` (this HACS integration) is
+supported. Please reproduce any issue on the current release before reporting.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report privately via GitHub's **"Report a vulnerability"** button under the
+repository's *Security* tab (Security Advisories), or contact the maintainer
+[@tschamm](https://github.com/tschamm) directly. We'll acknowledge the report
+and work with you on a fix and coordinated disclosure.
+
+## Scope / context
+
+This integration talks to the Bosch Smart Home Controller **only over the local
+network**, using a mutual-TLS client certificate (no cloud component). There is
+no external/cloud attack surface in this project itself.
+
+When reporting, please **never include** secrets or personal data — no client
+certificates/keys, controller passwords, home IP addresses/SSIDs, or real device
+serials/cloud IDs. Use redacted/fake values in any logs or rawscans you attach.


### PR DESCRIPTION
## What
Brings the repo's GitHub **community profile** up to standard (mirroring the camera-tool repo). All additive docs/templates — no code touched.

- **CONTRIBUTING.md** — PR-from-fork flow, flake8 (88 / ignore E501,W503) + `scripts/local-ci.sh` gate, unit tests under `tests/bosch_shc/` (config_flow/device_trigger need the HA harness → upstream CI), rawscan for device bug reports, no PII/secrets/real serials.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1.
- **SECURITY.md** — private reporting (Security Advisories), local-network mTLS scope, redact secrets/PII.
- **.github/ISSUE_TEMPLATE/** — `bug_report.yml` (HA / integration / boschshcpy / SHC-gen / model + debug-log + rawscan fields), `feature_request.yml`, `config.yml`.
- **.github/PULL_REQUEST_TEMPLATE.md** — issue ref as bare `#N` (note: no auto-close keywords), tests/flake8 checklist.
- **.github/DISCUSSION_TEMPLATE/** — question / idea / show-and-tell / general.

## Needs you, @tschamm (owner-only)
Please enable **Discussions** (Settings → General → Features → ✅ Discussions). Neither I nor @mosandlt have admin to flip it. The 4 discussion templates here activate as soon as it's on.

No rush — merge whatever subset you're happy with.
