### PR TITLE
Map Room Climate direction→hvac_mode, regulation→preset_mode

### DIFF
--- a/custom_components/bosch_shc/boschshcpy_patch.py
+++ b/custom_components/bosch_shc/boschshcpy_patch.py
@@ -1,0 +1,18 @@
+"""Temporary shim: attach supports_eco to boschshcpy until the library releases it.
+
+Remove this file and the two import/apply lines in climate.py once the
+boschshcpy release that adds supports_eco is set as the minimum requirement in
+manifest.json.
+"""
+from __future__ import annotations
+
+
+def apply() -> None:
+    """Monkey-patch supports_eco onto SHCClimateControl if not already present."""
+    try:
+        from boschshcpy import SHCClimateControl
+    except ImportError:
+        return
+
+    if not hasattr(SHCClimateControl, "supports_eco"):
+        SHCClimateControl.supports_eco = property(lambda self: True)

--- a/custom_components/bosch_shc/climate.py
+++ b/custom_components/bosch_shc/climate.py
@@ -15,6 +15,9 @@ from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 
 from .const import DATA_SESSION, DOMAIN, LOGGER
 from .entity import SHCEntity
+from . import boschshcpy_patch
+
+boschshcpy_patch.apply()
 
 # Bosch separates two orthogonal axes that HA's single hvac_mode enum cannot
 # express together:
@@ -124,10 +127,15 @@ class ClimateControl(SHCEntity, ClimateEntity):
     @property
     def hvac_modes(self):
         """Return available hvac modes."""
-        modes = [HVACMode.HEAT, HVACMode.OFF]
+        modes = [HVACMode.HEAT]
         if self._device.supports_cooling:
             modes.append(HVACMode.COOL)
+        modes.append(HVACMode.OFF)
         return modes
+
+    @property
+    def _supports_eco(self) -> bool:
+        return getattr(self._device, "supports_eco", True)
 
     @property
     def hvac_action(self):
@@ -152,7 +160,7 @@ class ClimateControl(SHCEntity, ClimateEntity):
         if self._device.supports_boost_mode and self._device.boost_mode:
             return PRESET_BOOST
 
-        if self._device.low:
+        if self._supports_eco and self._device.low:
             return PRESET_ECO
 
         if (
@@ -166,9 +174,11 @@ class ClimateControl(SHCEntity, ClimateEntity):
     @property
     def preset_modes(self):
         """Return available preset modes."""
-        presets = [PRESET_AUTO, PRESET_MANUAL, PRESET_ECO]
+        presets = [PRESET_AUTO, PRESET_MANUAL]
+        if self._supports_eco:
+            presets.append(PRESET_ECO)
         if self._device.supports_boost_mode:
-            presets += [PRESET_BOOST]
+            presets.append(PRESET_BOOST)
         return presets
 
     @property

--- a/custom_components/bosch_shc/climate.py
+++ b/custom_components/bosch_shc/climate.py
@@ -10,12 +10,21 @@ from homeassistant.components.climate.const import (
     ClimateEntityFeature,
     PRESET_BOOST,
     PRESET_ECO,
-    PRESET_NONE,
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 
 from .const import DATA_SESSION, DOMAIN, LOGGER
 from .entity import SHCEntity
+
+# Bosch separates two orthogonal axes that HA's single hvac_mode enum cannot
+# express together:
+#   * direction : HEATING / COOLING   (roomControlMode)  -> hvac_mode heat/cool
+#   * regulation: AUTOMATIC / MANUAL  (operationMode)    -> preset auto/manual
+# We therefore map the regulation axis onto preset_mode. The eco ("low") and
+# boost overrides remain additional presets that take display precedence while
+# active but do not destroy the underlying auto/manual regulation in the SHC.
+PRESET_AUTO = "auto"
+PRESET_MANUAL = "manual"
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -51,6 +60,7 @@ class ClimateControl(SHCEntity, ClimateEntity):
 
     _attr_target_temperature_step = 0.5
     _enable_turn_on_off_backwards_compatibility = False
+    _attr_translation_key = "room_climate"
 
     def __init__(
         self,
@@ -102,25 +112,19 @@ class ClimateControl(SHCEntity, ClimateEntity):
 
     @property
     def hvac_mode(self):
-        """Return the hvac mode."""
+        """Return the hvac mode (direction axis only: heat / cool / off)."""
         if self._device.summer_mode:
             return HVACMode.OFF
 
         if self._device.supports_cooling and self._device.cooling_mode:
             return HVACMode.COOL
 
-        if (
-            self._device.operation_mode
-            == SHCClimateControl.RoomClimateControlService.OperationMode.AUTOMATIC
-        ):
-            return HVACMode.AUTO
-
         return HVACMode.HEAT
 
     @property
     def hvac_modes(self):
         """Return available hvac modes."""
-        modes = [HVACMode.AUTO, HVACMode.HEAT, HVACMode.OFF]
+        modes = [HVACMode.HEAT, HVACMode.OFF]
         if self._device.supports_cooling:
             modes.append(HVACMode.COOL)
         return modes
@@ -131,28 +135,38 @@ class ClimateControl(SHCEntity, ClimateEntity):
         if self.hvac_mode == HVACMode.OFF:
             return HVACAction.OFF
         # getattr guard: has_demand needs boschshcpy >= 0.2.120; tolerate older libs
-        return (
-            HVACAction.HEATING
-            if getattr(self._device, "has_demand", False)
-            else HVACAction.IDLE
-        )
+        if not getattr(self._device, "has_demand", False):
+            return HVACAction.IDLE
+        if self._device.supports_cooling and self._device.cooling_mode:
+            return HVACAction.COOLING
+        return HVACAction.HEATING
 
     @property
     def preset_mode(self):
-        """Return preset mode."""
-        if self._device.supports_boost_mode:
-            if self._device.boost_mode:
-                return PRESET_BOOST
+        """Return preset mode.
+
+        The preset carries the regulation axis (auto / manual). The eco and
+        boost overrides take display precedence while active, since they are
+        temporary states the user typically wants to see and clear.
+        """
+        if self._device.supports_boost_mode and self._device.boost_mode:
+            return PRESET_BOOST
 
         if self._device.low:
             return PRESET_ECO
 
-        return PRESET_NONE
+        if (
+            self._device.operation_mode
+            == SHCClimateControl.RoomClimateControlService.OperationMode.AUTOMATIC
+        ):
+            return PRESET_AUTO
+
+        return PRESET_MANUAL
 
     @property
     def preset_modes(self):
         """Return available preset modes."""
-        presets = [PRESET_NONE, PRESET_ECO]
+        presets = [PRESET_AUTO, PRESET_MANUAL, PRESET_ECO]
         if self._device.supports_boost_mode:
             presets += [PRESET_BOOST]
         return presets
@@ -173,9 +187,10 @@ class ClimateControl(SHCEntity, ClimateEntity):
         if temperature is None:
             return
 
-        await self.async_set_hvac_mode(
-            kwargs.get(ATTR_HVAC_MODE)
-        )  # set_temperature args may provide HVAC mode as well
+        hvac_mode = kwargs.get(ATTR_HVAC_MODE)
+        if hvac_mode is not None:
+            # set_temperature args may provide HVAC mode as well
+            await self.async_set_hvac_mode(hvac_mode)
 
         if self.hvac_mode == HVACMode.OFF or self.preset_mode == PRESET_ECO:
             LOGGER.debug(
@@ -208,53 +223,41 @@ class ClimateControl(SHCEntity, ClimateEntity):
                 )
 
     async def async_set_hvac_mode(self, hvac_mode: str):
-        """Set hvac mode."""
+        """Set hvac mode (direction axis only).
+
+        Heating/cooling direction is orthogonal to the auto/manual regulation,
+        which is handled via preset_mode. Changing direction must therefore not
+        touch operation_mode, otherwise cooling+auto / heating+auto would be
+        impossible to express.
+        """
         if hvac_mode not in self.hvac_modes:
             return
         if self.preset_mode == PRESET_ECO:
             return
 
         try:
-            if hvac_mode == HVACMode.AUTO:
-                await self.hass.async_add_executor_job(
-                    setattr, self._device, "summer_mode", False
-                )
-                if self._device.supports_cooling:
-                    await self.hass.async_add_executor_job(
-                        setattr, self._device, "cooling_mode", False
-                    )
-                await self.hass.async_add_executor_job(
-                    setattr,
-                    self._device,
-                    "operation_mode",
-                    SHCClimateControl.RoomClimateControlService.OperationMode.AUTOMATIC,
-                )
             if hvac_mode == HVACMode.HEAT:
                 await self.hass.async_add_executor_job(
                     setattr, self._device, "summer_mode", False
                 )
-                if self._device.supports_cooling:
+                if self._device.supports_cooling and self._device.cooling_mode:
                     await self.hass.async_add_executor_job(
                         setattr, self._device, "cooling_mode", False
                     )
-                await self.hass.async_add_executor_job(
-                    setattr,
-                    self._device,
-                    "operation_mode",
-                    SHCClimateControl.RoomClimateControlService.OperationMode.MANUAL,
-                )
-            if hvac_mode == HVACMode.COOL:
+            elif hvac_mode == HVACMode.COOL:
+                if not self._device.supports_cooling:
+                    LOGGER.warning(
+                        "Device %s does not support cooling.", self.device_name
+                    )
+                    return
                 await self.hass.async_add_executor_job(
                     setattr, self._device, "summer_mode", False
                 )
-                await self.hass.async_add_executor_job(
-                    setattr, self._device, "cooling_mode", True
-                )
-            if hvac_mode == HVACMode.OFF:
-                if self._device.supports_cooling:
+                if not self._device.cooling_mode:
                     await self.hass.async_add_executor_job(
-                        setattr, self._device, "cooling_mode", False
+                        setattr, self._device, "cooling_mode", True
                     )
+            elif hvac_mode == HVACMode.OFF:
                 await self.hass.async_add_executor_job(
                     setattr, self._device, "summer_mode", True
                 )
@@ -266,21 +269,38 @@ class ClimateControl(SHCEntity, ClimateEntity):
             )
 
     async def async_set_preset_mode(self, preset_mode: str):
-        """Set preset mode."""
+        """Set preset mode.
+
+        auto / manual write the regulation axis (operation_mode) and clear any
+        eco/boost override. eco / boost set their override on top of the current
+        regulation without changing it, so returning to auto/manual restores the
+        previous behaviour.
+        """
         if preset_mode not in self.preset_modes:
             return
 
-        try:
-            if preset_mode == PRESET_NONE:
-                if self._device.supports_boost_mode:
-                    if self._device.boost_mode:
-                        await self.hass.async_add_executor_job(
-                            setattr, self._device, "boost_mode", False
-                        )
+        OperationMode = (
+            SHCClimateControl.RoomClimateControlService.OperationMode
+        )
 
+        try:
+            if preset_mode in (PRESET_AUTO, PRESET_MANUAL):
+                if self._device.supports_boost_mode and self._device.boost_mode:
+                    await self.hass.async_add_executor_job(
+                        setattr, self._device, "boost_mode", False
+                    )
                 if self._device.low:
                     await self.hass.async_add_executor_job(
                         setattr, self._device, "low", False
+                    )
+                target = (
+                    OperationMode.AUTOMATIC
+                    if preset_mode == PRESET_AUTO
+                    else OperationMode.MANUAL
+                )
+                if self._device.operation_mode != target:
+                    await self.hass.async_add_executor_job(
+                        setattr, self._device, "operation_mode", target
                     )
 
             elif preset_mode == PRESET_BOOST:
@@ -288,19 +308,16 @@ class ClimateControl(SHCEntity, ClimateEntity):
                     await self.hass.async_add_executor_job(
                         setattr, self._device, "boost_mode", True
                     )
-
                 if self._device.low:
                     await self.hass.async_add_executor_job(
                         setattr, self._device, "low", False
                     )
 
             elif preset_mode == PRESET_ECO:
-                if self._device.supports_boost_mode:
-                    if self._device.boost_mode:
-                        await self.hass.async_add_executor_job(
-                            setattr, self._device, "boost_mode", False
-                        )
-
+                if self._device.supports_boost_mode and self._device.boost_mode:
+                    await self.hass.async_add_executor_job(
+                        setattr, self._device, "boost_mode", False
+                    )
                 if not self._device.low:
                     await self.hass.async_add_executor_job(
                         setattr, self._device, "low", True

--- a/custom_components/bosch_shc/icons.json
+++ b/custom_components/bosch_shc/icons.json
@@ -5,8 +5,8 @@
         "state_attributes": {
           "preset_mode": {
             "state": {
-              "auto": "mdi:calendar-clock",
-              "manual": "mdi:hand-back-right",
+              "auto": "mdi:clock-outline",
+              "manual": "mdi:hand-pointing-up",
               "eco": "mdi:leaf",
               "boost": "mdi:rocket-launch"
             }

--- a/custom_components/bosch_shc/icons.json
+++ b/custom_components/bosch_shc/icons.json
@@ -1,0 +1,18 @@
+{
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "mdi:calendar-clock",
+              "manual": "mdi:hand-back-right",
+              "eco": "mdi:leaf",
+              "boost": "mdi:rocket-launch"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/custom_components/bosch_shc/translations/bg.json
+++ b/custom_components/bosch_shc/translations/bg.json
@@ -1,24 +1,40 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "\u0423\u0441\u0442\u0440\u043e\u0439\u0441\u0442\u0432\u043e\u0442\u043e \u0432\u0435\u0447\u0435 \u0435 \u043a\u043e\u043d\u0444\u0438\u0433\u0443\u0440\u0438\u0440\u0430\u043d\u043e",
-            "reauth_successful": "\u041f\u043e\u0432\u0442\u043e\u0440\u043d\u0430\u0442\u0430 \u0430\u0432\u0442\u0435\u043d\u0442\u0438\u043a\u0430\u0446\u0438\u044f \u0431\u0435\u0448\u0435 \u0443\u0441\u043f\u0435\u0448\u043d\u0430"
-        },
-        "error": {
-            "cannot_connect": "\u041d\u0435\u0443\u0441\u043f\u0435\u0448\u043d\u043e \u0441\u0432\u044a\u0440\u0437\u0432\u0430\u043d\u0435",
-            "invalid_auth": "\u041d\u0435\u0432\u0430\u043b\u0438\u0434\u043d\u043e \u0443\u0434\u043e\u0441\u0442\u043e\u0432\u0435\u0440\u044f\u0432\u0430\u043d\u0435",
-            "unknown": "\u041d\u0435\u043e\u0447\u0430\u043a\u0432\u0430\u043d\u0430 \u0433\u0440\u0435\u0448\u043a\u0430"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "reauth_confirm": {
-                "title": "\u041f\u043e\u0432\u0442\u043e\u0440\u043d\u043e \u0443\u0434\u043e\u0441\u0442\u043e\u0432\u0435\u0440\u044f\u0432\u0430\u043d\u0435 \u043d\u0430 \u0438\u043d\u0442\u0435\u0433\u0440\u0430\u0446\u0438\u044f\u0442\u0430"
-            },
-            "user": {
-                "data": {
-                    "host": "\u0425\u043e\u0441\u0442"
-                }
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Автоматично",
+              "manual": "Ръчно",
+              "eco": "Еко",
+              "boost": "Буст"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Устройството вече е конфигурирано",
+      "reauth_successful": "Повторната автентикация беше успешна"
+    },
+    "error": {
+      "cannot_connect": "Неуспешно свързване",
+      "invalid_auth": "Невалидно удостоверяване",
+      "unknown": "Неочаквана грешка"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "reauth_confirm": {
+        "title": "Повторно удостоверяване на интеграцията"
+      },
+      "user": {
+        "data": {
+          "host": "Хост"
+        }
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/ca.json
+++ b/custom_components/bosch_shc/translations/ca.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "El dispositiu ja est\u00e0 configurat",
-            "reauth_successful": "Re-autenticaci\u00f3 realitzada correctament"
-        },
-        "error": {
-            "cannot_connect": "Ha fallat la connexi\u00f3",
-            "invalid_auth": "Autenticaci\u00f3 inv\u00e0lida",
-            "pairing_failed": "La vinculaci\u00f3 ha fallat; comprova que el controlador Bosch Smart Home est\u00e0 en mode vinculaci\u00f3 (LED parpellejant) i que la contrasenya \u00e9s correcta.",
-            "session_error": "Error de sessi\u00f3: l'API ha retornat No OK.",
-            "unknown": "Error inesperat"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "Prem el bot\u00f3 de la part frontal/lateral del controlador Bosh Smart Home fins que el LED parpellegi.\nPreparat per continuar la configuraci\u00f3 de {model} @ {host} amb Home Assistant?"
-            },
-            "credentials": {
-                "data": {
-                    "password": "Contrasenya de Smart Home Controller"
-                }
-            },
-            "reauth_confirm": {
-                "description": "La integraci\u00f3 bosch_shc ha de tornar a autenticar el teu compte",
-                "title": "Reautenticaci\u00f3 de la integraci\u00f3"
-            },
-            "user": {
-                "data": {
-                    "host": "Amfitri\u00f3"
-                },
-                "description": "Configura Bosch Smart Controller per poder controlar i monitoritzar-lo des de Home Assistant.",
-                "title": "Par\u00e0metres d'autenticaci\u00f3 SHC"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automàtic",
+              "manual": "Manual",
+              "eco": "Eco",
+              "boost": "Boost"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "El dispositiu ja està configurat",
+      "reauth_successful": "Re-autenticació realitzada correctament"
+    },
+    "error": {
+      "cannot_connect": "Ha fallat la connexió",
+      "invalid_auth": "Autenticació invàlida",
+      "pairing_failed": "La vinculació ha fallat; comprova que el controlador Bosch Smart Home està en mode vinculació (LED parpellejant) i que la contrasenya és correcta.",
+      "session_error": "Error de sessió: l'API ha retornat No OK.",
+      "unknown": "Error inesperat"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "Prem el botó de la part frontal/lateral del controlador Bosh Smart Home fins que el LED parpellegi.\nPreparat per continuar la configuració de {model} @ {host} amb Home Assistant?"
+      },
+      "credentials": {
+        "data": {
+          "password": "Contrasenya de Smart Home Controller"
+        }
+      },
+      "reauth_confirm": {
+        "description": "La integració bosch_shc ha de tornar a autenticar el teu compte",
+        "title": "Reautenticació de la integració"
+      },
+      "user": {
+        "data": {
+          "host": "Amfitrió"
+        },
+        "description": "Configura Bosch Smart Controller per poder controlar i monitoritzar-lo des de Home Assistant.",
+        "title": "Paràmetres d'autenticació SHC"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/cs.json
+++ b/custom_components/bosch_shc/translations/cs.json
@@ -1,23 +1,39 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Za\u0159\u00edzen\u00ed je ji\u017e nastaveno",
-            "reauth_successful": "Op\u011btovn\u00e9 ov\u011b\u0159en\u00ed bylo \u00fasp\u011b\u0161n\u00e9"
-        },
-        "error": {
-            "cannot_connect": "Nepoda\u0159ilo se p\u0159ipojit",
-            "invalid_auth": "Neplatn\u00e9 ov\u011b\u0159en\u00ed",
-            "unknown": "Neo\u010dek\u00e1van\u00e1 chyba"
-        },
-        "step": {
-            "reauth_confirm": {
-                "title": "Znovu ov\u011b\u0159it integraci"
-            },
-            "user": {
-                "data": {
-                    "host": "Hostitel"
-                }
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automaticky",
+              "manual": "Ručně",
+              "eco": "Eco",
+              "boost": "Boost"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Zařízení je již nastaveno",
+      "reauth_successful": "Opětovné ověření bylo úspěšné"
+    },
+    "error": {
+      "cannot_connect": "Nepodařilo se připojit",
+      "invalid_auth": "Neplatné ověření",
+      "unknown": "Neočekávaná chyba"
+    },
+    "step": {
+      "reauth_confirm": {
+        "title": "Znovu ověřit integraci"
+      },
+      "user": {
+        "data": {
+          "host": "Hostitel"
+        }
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/de.json
+++ b/custom_components/bosch_shc/translations/de.json
@@ -1,4 +1,20 @@
 {
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automatik",
+              "manual": "Manuell",
+              "eco": "Eco",
+              "boost": "Boost"
+            }
+          }
+        }
+      }
+    }
+  },
   "config": {
     "abort": {
       "already_configured": "Ger\u00e4t ist bereits konfiguriert",

--- a/custom_components/bosch_shc/translations/el.json
+++ b/custom_components/bosch_shc/translations/el.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "\u0397 \u03c3\u03c5\u03c3\u03ba\u03b5\u03c5\u03ae \u03ad\u03c7\u03b5\u03b9 \u03ae\u03b4\u03b7 \u03b4\u03b9\u03b1\u03bc\u03bf\u03c1\u03c6\u03c9\u03b8\u03b5\u03af",
-            "reauth_successful": "\u039f \u03b5\u03ba \u03bd\u03ad\u03bf\u03c5 \u03ad\u03bb\u03b5\u03b3\u03c7\u03bf\u03c2 \u03c4\u03b1\u03c5\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1\u03c2 \u03ae\u03c4\u03b1\u03bd \u03b5\u03c0\u03b9\u03c4\u03c5\u03c7\u03ae\u03c2"
-        },
-        "error": {
-            "cannot_connect": "\u0391\u03c0\u03bf\u03c4\u03c5\u03c7\u03af\u03b1 \u03c3\u03cd\u03bd\u03b4\u03b5\u03c3\u03b7\u03c2",
-            "invalid_auth": "\u039c\u03b7 \u03ad\u03b3\u03ba\u03c5\u03c1\u03bf\u03c2 \u03ad\u03bb\u03b5\u03b3\u03c7\u03bf\u03c2 \u03c4\u03b1\u03c5\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1\u03c2",
-            "pairing_failed": "\u0397 \u03c3\u03cd\u03b6\u03b5\u03c5\u03be\u03b7 \u03b1\u03c0\u03ad\u03c4\u03c5\u03c7\u03b5. \u03b5\u03bb\u03ad\u03b3\u03be\u03c4\u03b5 \u03cc\u03c4\u03b9 \u03c4\u03bf Bosch Smart Home Controller \u03b2\u03c1\u03af\u03c3\u03ba\u03b5\u03c4\u03b1\u03b9 \u03c3\u03b5 \u03bb\u03b5\u03b9\u03c4\u03bf\u03c5\u03c1\u03b3\u03af\u03b1 \u03c3\u03cd\u03b6\u03b5\u03c5\u03be\u03b7\u03c2 (\u03c4\u03bf LED \u03b1\u03bd\u03b1\u03b2\u03bf\u03c3\u03b2\u03ae\u03bd\u03b5\u03b9) \u03ba\u03b1\u03b8\u03ce\u03c2 \u03ba\u03b1\u03b9 \u03cc\u03c4\u03b9 \u03bf \u03ba\u03c9\u03b4\u03b9\u03ba\u03cc\u03c2 \u03c0\u03c1\u03cc\u03c3\u03b2\u03b1\u03c3\u03ae\u03c2 \u03c3\u03b1\u03c2 \u03b5\u03af\u03bd\u03b1\u03b9 \u03c3\u03c9\u03c3\u03c4\u03cc\u03c2.",
-            "session_error": "\u03a3\u03c6\u03ac\u03bb\u03bc\u03b1 \u03c3\u03c5\u03bd\u03b5\u03b4\u03c1\u03af\u03b1\u03c2: \u039c\u03b7 \u039f\u039a \u03b1\u03c0\u03bf\u03c4\u03ad\u03bb\u03b5\u03c3\u03bc\u03b1.",
-            "unknown": "\u0391\u03c0\u03c1\u03cc\u03c3\u03bc\u03b5\u03bd\u03bf \u03c3\u03c6\u03ac\u03bb\u03bc\u03b1"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "\u03a0\u03b1\u03c4\u03ae\u03c3\u03c4\u03b5 \u03c4\u03bf \u03ba\u03bf\u03c5\u03bc\u03c0\u03af \u03c3\u03c4\u03b7\u03bd \u03bc\u03c0\u03c1\u03bf\u03c3\u03c4\u03b9\u03bd\u03ae \u03c0\u03bb\u03b5\u03c5\u03c1\u03ac \u03c4\u03bf\u03c5 Bosch Smart Home Controller \u03bc\u03ad\u03c7\u03c1\u03b9 \u03bd\u03b1 \u03b1\u03c1\u03c7\u03af\u03c3\u03b5\u03b9 \u03bd\u03b1 \u03b1\u03bd\u03b1\u03b2\u03bf\u03c3\u03b2\u03ae\u03bd\u03b5\u03b9 \u03b7 \u03bb\u03c5\u03c7\u03bd\u03af\u03b1 LED.\n \u0395\u03af\u03c3\u03c4\u03b5 \u03ad\u03c4\u03bf\u03b9\u03bc\u03bf\u03b9 \u03bd\u03b1 \u03c3\u03c5\u03bd\u03b5\u03c7\u03af\u03c3\u03b5\u03c4\u03b5 \u03bd\u03b1 \u03c1\u03c5\u03b8\u03bc\u03af\u03b6\u03b5\u03c4\u03b5 \u03c4\u03bf {model} @ {host} \u03bc\u03b5 \u03c4\u03bf Home Assistant;"
-            },
-            "credentials": {
-                "data": {
-                    "password": "\u039a\u03c9\u03b4\u03b9\u03ba\u03cc\u03c2 \u03c0\u03c1\u03cc\u03c3\u03b2\u03b1\u03c3\u03b7\u03c2 \u03c4\u03bf\u03c5 Smart Home Controller"
-                }
-            },
-            "reauth_confirm": {
-                "description": "\u0397 \u03b5\u03bd\u03c3\u03c9\u03bc\u03ac\u03c4\u03c9\u03c3\u03b7 bosch_shc \u03c0\u03c1\u03ad\u03c0\u03b5\u03b9 \u03bd\u03b1 \u03c0\u03b9\u03c3\u03c4\u03bf\u03c0\u03bf\u03b9\u03ae\u03c3\u03b5\u03b9 \u03b5\u03ba \u03bd\u03ad\u03bf\u03c5 \u03c4\u03bf \u03bb\u03bf\u03b3\u03b1\u03c1\u03b9\u03b1\u03c3\u03bc\u03cc \u03c3\u03b1\u03c2",
-                "title": "\u0395\u03c0\u03b1\u03bd\u03b1\u03bb\u03b7\u03c0\u03c4\u03b9\u03ba\u03cc\u03c2 \u03ad\u03bb\u03b5\u03b3\u03c7\u03bf\u03c2 \u03c4\u03b1\u03c5\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1\u03c2 \u03b5\u03bd\u03c3\u03c9\u03bc\u03ac\u03c4\u03c9\u03c3\u03b7\u03c2"
-            },
-            "user": {
-                "data": {
-                    "host": "\u039a\u03b5\u03bd\u03c4\u03c1\u03b9\u03ba\u03cc\u03c2 \u03c5\u03c0\u03bf\u03bb\u03bf\u03b3\u03b9\u03c3\u03c4\u03ae\u03c2"
-                },
-                "description": "\u03a1\u03c5\u03b8\u03bc\u03af\u03c3\u03c4\u03b5 \u03c4\u03bf Bosch Smart Home Controller \u03b3\u03b9\u03b1 \u03bd\u03b1 \u03b5\u03c0\u03b9\u03c4\u03c1\u03ad\u03c0\u03b5\u03b9 \u03c4\u03b7\u03bd \u03c0\u03b1\u03c1\u03b1\u03ba\u03bf\u03bb\u03bf\u03cd\u03b8\u03b7\u03c3\u03b7 \u03ba\u03b1\u03b9 \u03c4\u03bf\u03bd \u03ad\u03bb\u03b5\u03b3\u03c7\u03bf \u03bc\u03b5 \u03c4\u03bf Home Assistant.",
-                "title": "\u03a0\u03b1\u03c1\u03ac\u03bc\u03b5\u03c4\u03c1\u03bf\u03b9 \u03b5\u03bb\u03ad\u03b3\u03c7\u03bf\u03c5 \u03c4\u03b1\u03c5\u03c4\u03cc\u03c4\u03b7\u03c4\u03b1\u03c2 SHC"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Αυτόματο",
+              "manual": "Χειροκίνητο",
+              "eco": "Eco",
+              "boost": "Boost"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Η συσκευή έχει ήδη διαμορφωθεί",
+      "reauth_successful": "Ο εκ νέου έλεγχος ταυτότητας ήταν επιτυχής"
+    },
+    "error": {
+      "cannot_connect": "Αποτυχία σύνδεσης",
+      "invalid_auth": "Μη έγκυρος έλεγχος ταυτότητας",
+      "pairing_failed": "Η σύζευξη απέτυχε. ελέγξτε ότι το Bosch Smart Home Controller βρίσκεται σε λειτουργία σύζευξης (το LED αναβοσβήνει) καθώς και ότι ο κωδικός πρόσβασής σας είναι σωστός.",
+      "session_error": "Σφάλμα συνεδρίας: Μη ΟΚ αποτέλεσμα.",
+      "unknown": "Απρόσμενο σφάλμα"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "Πατήστε το κουμπί στην μπροστινή πλευρά του Bosch Smart Home Controller μέχρι να αρχίσει να αναβοσβήνει η λυχνία LED.\n Είστε έτοιμοι να συνεχίσετε να ρυθμίζετε το {model} @ {host} με το Home Assistant;"
+      },
+      "credentials": {
+        "data": {
+          "password": "Κωδικός πρόσβασης του Smart Home Controller"
+        }
+      },
+      "reauth_confirm": {
+        "description": "Η ενσωμάτωση bosch_shc πρέπει να πιστοποιήσει εκ νέου το λογαριασμό σας",
+        "title": "Επαναληπτικός έλεγχος ταυτότητας ενσωμάτωσης"
+      },
+      "user": {
+        "data": {
+          "host": "Κεντρικός υπολογιστής"
+        },
+        "description": "Ρυθμίστε το Bosch Smart Home Controller για να επιτρέπει την παρακολούθηση και τον έλεγχο με το Home Assistant.",
+        "title": "Παράμετροι ελέγχου ταυτότητας SHC"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/en.json
+++ b/custom_components/bosch_shc/translations/en.json
@@ -1,4 +1,20 @@
 {
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Auto",
+              "manual": "Manual",
+              "eco": "Eco",
+              "boost": "Boost"
+            }
+          }
+        }
+      }
+    }
+  },
   "config": {
     "abort": {
       "already_configured": "Device is already configured",

--- a/custom_components/bosch_shc/translations/es-419.json
+++ b/custom_components/bosch_shc/translations/es-419.json
@@ -1,21 +1,37 @@
 {
-    "config": {
-        "step": {
-            "confirm_discovery": {
-                "description": "Presione el bot\u00f3n frontal del Controlador de Hogar Inteligente de Bosch hasta que el LED comience a parpadear.\n\u00bfListo para continuar configurando {model} @ {host} con Home Assistant?"
-            },
-            "credentials": {
-                "data": {
-                    "password": "Contrase\u00f1a del controlador Smart Home"
-                }
-            },
-            "reauth_confirm": {
-                "description": "La integraci\u00f3n bosch_shc necesita volver a autenticar su cuenta"
-            },
-            "user": {
-                "description": "Configure su controlador de hogar inteligente de Bosch para permitir la supervisi\u00f3n y el control con Home Assistant.",
-                "title": "Par\u00e1metros de autenticaci\u00f3n SHC"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automático",
+              "manual": "Manual",
+              "eco": "Eco",
+              "boost": "Boost"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "step": {
+      "confirm_discovery": {
+        "description": "Presione el botón frontal del Controlador de Hogar Inteligente de Bosch hasta que el LED comience a parpadear.\n¿Listo para continuar configurando {model} @ {host} con Home Assistant?"
+      },
+      "credentials": {
+        "data": {
+          "password": "Contraseña del controlador Smart Home"
+        }
+      },
+      "reauth_confirm": {
+        "description": "La integración bosch_shc necesita volver a autenticar su cuenta"
+      },
+      "user": {
+        "description": "Configure su controlador de hogar inteligente de Bosch para permitir la supervisión y el control con Home Assistant.",
+        "title": "Parámetros de autenticación SHC"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/es.json
+++ b/custom_components/bosch_shc/translations/es.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "El dispositivo ya est\u00e1 configurado",
-            "reauth_successful": "La autenticaci\u00f3n se volvi\u00f3 a realizar correctamente"
-        },
-        "error": {
-            "cannot_connect": "No se pudo conectar",
-            "invalid_auth": "Autenticaci\u00f3n no v\u00e1lida",
-            "pairing_failed": "Emparejamiento fallido; por favor, comprueba que el Smart Home Controller de Bosch est\u00e9 en modo de emparejamiento (el LED parpadea) y que tu contrase\u00f1a sea correcta.",
-            "session_error": "Error de sesi\u00f3n: la API devuelve un resultado No-OK.",
-            "unknown": "Error inesperado"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "Por favor, pulsa el bot\u00f3n frontal del Smart Home Controller de Bosch hasta que el LED empiece a parpadear.\n\u00bfPreparado para seguir configurando {model} @ {host} con Home Assistant?"
-            },
-            "credentials": {
-                "data": {
-                    "password": "Contrase\u00f1a del Smart Home Controller"
-                }
-            },
-            "reauth_confirm": {
-                "description": "La integraci\u00f3n bosch_shc necesita volver a autentificar tu cuenta",
-                "title": "Volver a autenticar la integraci\u00f3n"
-            },
-            "user": {
-                "data": {
-                    "host": "Host"
-                },
-                "description": "Configura tu Bosch Smart Home Controller para permitir la supervisi\u00f3n y el control con Home Assistant.",
-                "title": "Par\u00e1metros de autenticaci\u00f3n SHC"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automático",
+              "manual": "Manual",
+              "eco": "Eco",
+              "boost": "Boost"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "El dispositivo ya está configurado",
+      "reauth_successful": "La autenticación se volvió a realizar correctamente"
+    },
+    "error": {
+      "cannot_connect": "No se pudo conectar",
+      "invalid_auth": "Autenticación no válida",
+      "pairing_failed": "Emparejamiento fallido; por favor, comprueba que el Smart Home Controller de Bosch esté en modo de emparejamiento (el LED parpadea) y que tu contraseña sea correcta.",
+      "session_error": "Error de sesión: la API devuelve un resultado No-OK.",
+      "unknown": "Error inesperado"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "Por favor, pulsa el botón frontal del Smart Home Controller de Bosch hasta que el LED empiece a parpadear.\n¿Preparado para seguir configurando {model} @ {host} con Home Assistant?"
+      },
+      "credentials": {
+        "data": {
+          "password": "Contraseña del Smart Home Controller"
+        }
+      },
+      "reauth_confirm": {
+        "description": "La integración bosch_shc necesita volver a autentificar tu cuenta",
+        "title": "Volver a autenticar la integración"
+      },
+      "user": {
+        "data": {
+          "host": "Host"
+        },
+        "description": "Configura tu Bosch Smart Home Controller para permitir la supervisión y el control con Home Assistant.",
+        "title": "Parámetros de autenticación SHC"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/et.json
+++ b/custom_components/bosch_shc/translations/et.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Seade on juba h\u00e4\u00e4lestatud",
-            "reauth_successful": "Taastuvastamine \u00f5nnestus"
-        },
-        "error": {
-            "cannot_connect": "\u00dchendamine nurjus",
-            "invalid_auth": "Tuvastamise viga",
-            "pairing_failed": "Sidumine nurjus; palun kontrolli kas Bosch Smart Home Controller on sidumisre\u017eiimis (LED vilgub) ning kas salas\u00f5na on \u00f5ige.",
-            "session_error": "Seansi viga: API tagastas veateate.",
-            "unknown": "Tundmatu viga"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "Vajuta palun Bosch Smart Home Controlleri esik\u00fclje nuppu kuni LED hakkab vilkuma.\n Kas oled valmis j\u00e4tkama {model} @ {host} seadistamist Home Assistanti abil?"
-            },
-            "credentials": {
-                "data": {
-                    "password": "Smart Home kontrolleri salas\u00f5na"
-                }
-            },
-            "reauth_confirm": {
-                "description": "Bosch_shc sidumine peab konto uuesti autentima.",
-                "title": "Taastuvastamine"
-            },
-            "user": {
-                "data": {
-                    "host": "Host"
-                },
-                "description": "Seadista oma Bosch Smart Home Controller, et v\u00f5imaldada j\u00e4lgimist ja juhtimist Home Assistantiga.",
-                "title": "SHC autentimisparameetrid"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automaatne",
+              "manual": "Käsitsi",
+              "eco": "Eco",
+              "boost": "Boost"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Seade on juba häälestatud",
+      "reauth_successful": "Taastuvastamine õnnestus"
+    },
+    "error": {
+      "cannot_connect": "Ühendamine nurjus",
+      "invalid_auth": "Tuvastamise viga",
+      "pairing_failed": "Sidumine nurjus; palun kontrolli kas Bosch Smart Home Controller on sidumisrežiimis (LED vilgub) ning kas salasõna on õige.",
+      "session_error": "Seansi viga: API tagastas veateate.",
+      "unknown": "Tundmatu viga"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "Vajuta palun Bosch Smart Home Controlleri esikülje nuppu kuni LED hakkab vilkuma.\n Kas oled valmis jätkama {model} @ {host} seadistamist Home Assistanti abil?"
+      },
+      "credentials": {
+        "data": {
+          "password": "Smart Home kontrolleri salasõna"
+        }
+      },
+      "reauth_confirm": {
+        "description": "Bosch_shc sidumine peab konto uuesti autentima.",
+        "title": "Taastuvastamine"
+      },
+      "user": {
+        "data": {
+          "host": "Host"
+        },
+        "description": "Seadista oma Bosch Smart Home Controller, et võimaldada jälgimist ja juhtimist Home Assistantiga.",
+        "title": "SHC autentimisparameetrid"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/fr.json
+++ b/custom_components/bosch_shc/translations/fr.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "L'appareil est d\u00e9j\u00e0 configur\u00e9",
-            "reauth_successful": "La r\u00e9-authentification a r\u00e9ussi"
-        },
-        "error": {
-            "cannot_connect": "\u00c9chec de connexion",
-            "invalid_auth": "Authentification non valide",
-            "pairing_failed": "L'appairage a \u00e9chou\u00e9\u00a0; veuillez v\u00e9rifier que le Bosch Smart Home Controller est en mode d'appairage (voyant clignotant) et que votre mot de passe est correct.",
-            "session_error": "Erreur de session\u00a0: l'API renvoie un r\u00e9sultat non-OK.",
-            "unknown": "Erreur inattendue"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "Veuillez appuyer sur le bouton situ\u00e9 \u00e0 l'avant du Bosch Smart Home Controller jusqu'\u00e0 ce que le voyant commence \u00e0 clignoter.\n Pr\u00eat \u00e0 continuer \u00e0 configurer {model} @ {host} avec Home Assistant\u00a0?"
-            },
-            "credentials": {
-                "data": {
-                    "password": "Mot de passe du contr\u00f4leur Smart Home"
-                }
-            },
-            "reauth_confirm": {
-                "description": "L'int\u00e9gration bosch_shc doit r\u00e9-authentifier votre compte",
-                "title": "R\u00e9-authentifier l'int\u00e9gration"
-            },
-            "user": {
-                "data": {
-                    "host": "H\u00f4te"
-                },
-                "description": "Configurez votre Bosch Smart Home Controller pour permettre la surveillance et le contr\u00f4le avec Home Assistant.",
-                "title": "Param\u00e8tres d'authentification SHC"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automatique",
+              "manual": "Manuel",
+              "eco": "Eco",
+              "boost": "Boost"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "L'appareil est déjà configuré",
+      "reauth_successful": "La ré-authentification a réussi"
+    },
+    "error": {
+      "cannot_connect": "Échec de connexion",
+      "invalid_auth": "Authentification non valide",
+      "pairing_failed": "L'appairage a échoué ; veuillez vérifier que le Bosch Smart Home Controller est en mode d'appairage (voyant clignotant) et que votre mot de passe est correct.",
+      "session_error": "Erreur de session : l'API renvoie un résultat non-OK.",
+      "unknown": "Erreur inattendue"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "Veuillez appuyer sur le bouton situé à l'avant du Bosch Smart Home Controller jusqu'à ce que le voyant commence à clignoter.\n Prêt à continuer à configurer {model} @ {host} avec Home Assistant ?"
+      },
+      "credentials": {
+        "data": {
+          "password": "Mot de passe du contrôleur Smart Home"
+        }
+      },
+      "reauth_confirm": {
+        "description": "L'intégration bosch_shc doit ré-authentifier votre compte",
+        "title": "Ré-authentifier l'intégration"
+      },
+      "user": {
+        "data": {
+          "host": "Hôte"
+        },
+        "description": "Configurez votre Bosch Smart Home Controller pour permettre la surveillance et le contrôle avec Home Assistant.",
+        "title": "Paramètres d'authentification SHC"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/he.json
+++ b/custom_components/bosch_shc/translations/he.json
@@ -1,32 +1,48 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "\u05ea\u05e6\u05d5\u05e8\u05ea \u05d4\u05d4\u05ea\u05e7\u05df \u05db\u05d1\u05e8 \u05e0\u05e7\u05d1\u05e2\u05d4",
-            "reauth_successful": "\u05d4\u05d0\u05d9\u05de\u05d5\u05ea \u05de\u05d7\u05d3\u05e9 \u05d4\u05e6\u05dc\u05d9\u05d7"
-        },
-        "error": {
-            "cannot_connect": "\u05d4\u05d4\u05ea\u05d7\u05d1\u05e8\u05d5\u05ea \u05e0\u05db\u05e9\u05dc\u05d4",
-            "invalid_auth": "\u05d0\u05d9\u05de\u05d5\u05ea \u05dc\u05d0 \u05d7\u05d5\u05e7\u05d9",
-            "pairing_failed": "\u05d4\u05e9\u05d9\u05d5\u05da \u05e0\u05db\u05e9\u05dc; \u05e0\u05d0 \u05d1\u05d3\u05d5\u05e7 \u05e9\u05d1\u05e7\u05e8 \u05d4\u05d1\u05d9\u05ea \u05d4\u05d7\u05db\u05dd \u05e9\u05dc Bosch \u05e0\u05de\u05e6\u05d0 \u05d1\u05de\u05e6\u05d1 \u05e9\u05d9\u05d5\u05da (\u05de\u05d4\u05d1\u05d4\u05d1 LED) \u05db\u05de\u05d5 \u05d2\u05dd \u05d4\u05e1\u05d9\u05e1\u05de\u05d4 \u05e9\u05dc\u05da \u05e0\u05db\u05d5\u05e0\u05d4.",
-            "unknown": "\u05e9\u05d2\u05d9\u05d0\u05d4 \u05d1\u05dc\u05ea\u05d9 \u05e6\u05e4\u05d5\u05d9\u05d4"
-        },
-        "step": {
-            "confirm_discovery": {
-                "description": "\u05dc\u05d7\u05e5 \u05e2\u05dc \u05db\u05e4\u05ea\u05d5\u05e8 \u05d4\u05e6\u05d3 \u05d4\u05e7\u05d3\u05de\u05d9 \u05e9\u05dc \u05d1\u05e7\u05e8\u05ea \u05d4\u05d1\u05d9\u05ea \u05d4\u05d7\u05db\u05dd \u05e9\u05dc Bosch \u05e2\u05d3 \u05e9\u05d4\u05e0\u05d5\u05e8\u05d9\u05ea \u05ea\u05ea\u05d7\u05d9\u05dc \u05dc\u05d4\u05d1\u05d4\u05d1.\n \u05de\u05d5\u05db\u05df \u05dc\u05d4\u05de\u05e9\u05d9\u05da \u05d5\u05dc\u05d4\u05d2\u05d3\u05d9\u05e8 \u05d0\u05ea {model} @ {host} \u05d1\u05d0\u05de\u05e6\u05e2\u05d5\u05ea Home Assistant?"
-            },
-            "credentials": {
-                "data": {
-                    "password": "\u05e1\u05d9\u05e1\u05de\u05ea \u05d1\u05e7\u05e8 \u05d4\u05d1\u05d9\u05ea \u05d4\u05d7\u05db\u05dd"
-                }
-            },
-            "reauth_confirm": {
-                "title": "\u05d0\u05d9\u05de\u05d5\u05ea \u05de\u05d7\u05d3\u05e9 \u05e9\u05dc \u05e9\u05d9\u05dc\u05d5\u05d1"
-            },
-            "user": {
-                "data": {
-                    "host": "\u05de\u05d0\u05e8\u05d7"
-                }
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "אוטומטי",
+              "manual": "ידני",
+              "eco": "אקו",
+              "boost": "בוסט"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "תצורת ההתקן כבר נקבעה",
+      "reauth_successful": "האימות מחדש הצליח"
+    },
+    "error": {
+      "cannot_connect": "ההתחברות נכשלה",
+      "invalid_auth": "אימות לא חוקי",
+      "pairing_failed": "השיוך נכשל; נא בדוק שבקר הבית החכם של Bosch נמצא במצב שיוך (מהבהב LED) כמו גם הסיסמה שלך נכונה.",
+      "unknown": "שגיאה בלתי צפויה"
+    },
+    "step": {
+      "confirm_discovery": {
+        "description": "לחץ על כפתור הצד הקדמי של בקרת הבית החכם של Bosch עד שהנורית תתחיל להבהב.\n מוכן להמשיך ולהגדיר את {model} @ {host} באמצעות Home Assistant?"
+      },
+      "credentials": {
+        "data": {
+          "password": "סיסמת בקר הבית החכם"
+        }
+      },
+      "reauth_confirm": {
+        "title": "אימות מחדש של שילוב"
+      },
+      "user": {
+        "data": {
+          "host": "מארח"
+        }
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/hu.json
+++ b/custom_components/bosch_shc/translations/hu.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Az eszk\u00f6z m\u00e1r konfigur\u00e1lva van",
-            "reauth_successful": "Az \u00fajrahiteles\u00edt\u00e9s sikeres volt."
-        },
-        "error": {
-            "cannot_connect": "Sikertelen csatlakoz\u00e1s",
-            "invalid_auth": "\u00c9rv\u00e9nytelen hiteles\u00edt\u00e9s",
-            "pairing_failed": "A p\u00e1ros\u00edt\u00e1s nem siker\u00fclt; K\u00e9rem, ellen\u0151rizze, hogy a Bosch Smart Home Controller p\u00e1ros\u00edt\u00e1si m\u00f3dban van-e (villog a LED), \u00e9s hogy a jelszava helyes-e.",
-            "session_error": "Munkamenet hiba: Az API nem OK eredm\u00e9nyt ad vissza.",
-            "unknown": "V\u00e1ratlan hiba t\u00f6rt\u00e9nt"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "K\u00e9rem, addig nyomja a Bosch Smart Home Controller el\u00fcls\u0151 gombj\u00e1t, am\u00edg a LED villogni nem kezd.\nK\u00e9szen \u00e1ll {model} @ {host} be\u00e1ll\u00edt\u00e1s\u00e1nak folytat\u00e1s\u00e1ra Home Assistant seg\u00edts\u00e9g\u00e9vel?"
-            },
-            "credentials": {
-                "data": {
-                    "password": "A Smart Home Controller jelszava"
-                }
-            },
-            "reauth_confirm": {
-                "description": "A bosch_shc integr\u00e1ci\u00f3nak \u00fajra hiteles\u00edtenie kell a fi\u00f3kj\u00e1t",
-                "title": "Integr\u00e1ci\u00f3 \u00fajrahiteles\u00edt\u00e9se"
-            },
-            "user": {
-                "data": {
-                    "host": "C\u00edm"
-                },
-                "description": "\u00c1ll\u00edtsa be a Bosch intelligens otthoni vez\u00e9rl\u0151t, hogy lehet\u0151v\u00e9 tegye a fel\u00fcgyeletet \u00e9s a vez\u00e9rl\u00e9st Home Assistant seg\u00edts\u00e9g\u00e9vel.",
-                "title": "SHC hiteles\u00edt\u00e9si param\u00e9terek"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automatikus",
+              "manual": "Kézi",
+              "eco": "Eco",
+              "boost": "Boost"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Az eszköz már konfigurálva van",
+      "reauth_successful": "Az újrahitelesítés sikeres volt."
+    },
+    "error": {
+      "cannot_connect": "Sikertelen csatlakozás",
+      "invalid_auth": "Érvénytelen hitelesítés",
+      "pairing_failed": "A párosítás nem sikerült; Kérem, ellenőrizze, hogy a Bosch Smart Home Controller párosítási módban van-e (villog a LED), és hogy a jelszava helyes-e.",
+      "session_error": "Munkamenet hiba: Az API nem OK eredményt ad vissza.",
+      "unknown": "Váratlan hiba történt"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "Kérem, addig nyomja a Bosch Smart Home Controller elülső gombját, amíg a LED villogni nem kezd.\nKészen áll {model} @ {host} beállításának folytatására Home Assistant segítségével?"
+      },
+      "credentials": {
+        "data": {
+          "password": "A Smart Home Controller jelszava"
+        }
+      },
+      "reauth_confirm": {
+        "description": "A bosch_shc integrációnak újra hitelesítenie kell a fiókját",
+        "title": "Integráció újrahitelesítése"
+      },
+      "user": {
+        "data": {
+          "host": "Cím"
+        },
+        "description": "Állítsa be a Bosch intelligens otthoni vezérlőt, hogy lehetővé tegye a felügyeletet és a vezérlést Home Assistant segítségével.",
+        "title": "SHC hitelesítési paraméterek"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/id.json
+++ b/custom_components/bosch_shc/translations/id.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Perangkat sudah dikonfigurasi",
-            "reauth_successful": "Autentikasi ulang berhasil"
-        },
-        "error": {
-            "cannot_connect": "Gagal terhubung",
-            "invalid_auth": "Autentikasi tidak valid",
-            "pairing_failed": "Pemasangan gagal; periksa apakah Bosch Smart Home Controller dalam mode pemasangan (LED berkedip) dan kata sandi Anda benar.",
-            "session_error": "Kesalahan sesi: API mengembalikan hasil Non-OK.",
-            "unknown": "Kesalahan yang tidak diharapkan"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "Tekan tombol sisi depan Bosch Smart Home Controller hingga LED mulai berkedip.\nSiap melanjutkan penyiapan {model} @ {host} dengan Home Assistant?"
-            },
-            "credentials": {
-                "data": {
-                    "password": "Kata Sandi dari Smart Home Controller"
-                }
-            },
-            "reauth_confirm": {
-                "description": "Integrasi bosch_shc perlu mengautentikasi ulang akun Anda",
-                "title": "Autentikasi Ulang Integrasi"
-            },
-            "user": {
-                "data": {
-                    "host": "Host"
-                },
-                "description": "Siapkan Bosch Smart Home Controller Anda untuk memungkinkan pemantauan dan kontrol dengan Home Assistant.",
-                "title": "Parameter autentikasi SHC"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Otomatis",
+              "manual": "Manual",
+              "eco": "Eco",
+              "boost": "Boost"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Perangkat sudah dikonfigurasi",
+      "reauth_successful": "Autentikasi ulang berhasil"
+    },
+    "error": {
+      "cannot_connect": "Gagal terhubung",
+      "invalid_auth": "Autentikasi tidak valid",
+      "pairing_failed": "Pemasangan gagal; periksa apakah Bosch Smart Home Controller dalam mode pemasangan (LED berkedip) dan kata sandi Anda benar.",
+      "session_error": "Kesalahan sesi: API mengembalikan hasil Non-OK.",
+      "unknown": "Kesalahan yang tidak diharapkan"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "Tekan tombol sisi depan Bosch Smart Home Controller hingga LED mulai berkedip.\nSiap melanjutkan penyiapan {model} @ {host} dengan Home Assistant?"
+      },
+      "credentials": {
+        "data": {
+          "password": "Kata Sandi dari Smart Home Controller"
+        }
+      },
+      "reauth_confirm": {
+        "description": "Integrasi bosch_shc perlu mengautentikasi ulang akun Anda",
+        "title": "Autentikasi Ulang Integrasi"
+      },
+      "user": {
+        "data": {
+          "host": "Host"
+        },
+        "description": "Siapkan Bosch Smart Home Controller Anda untuk memungkinkan pemantauan dan kontrol dengan Home Assistant.",
+        "title": "Parameter autentikasi SHC"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/it.json
+++ b/custom_components/bosch_shc/translations/it.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Il dispositivo \u00e8 gi\u00e0 configurato",
-            "reauth_successful": "La nuova autenticazione \u00e8 stata eseguita correttamente"
-        },
-        "error": {
-            "cannot_connect": "Impossibile connettersi",
-            "invalid_auth": "Autenticazione non valida",
-            "pairing_failed": "Associazione non riuscita; verifica che il controller Bosch Smart Home sia in modalit\u00e0 di associazione (LED lampeggiante) e che la password sia corretta.",
-            "session_error": "Errore di sessione: l'API restituisce il risultato Non-OK.",
-            "unknown": "Errore imprevisto"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "Premi il pulsante sul lato anteriore del controller Bosch Smart Home finch\u00e9 il LED non inizia a lampeggiare.\nSei pronto per continuare a configurare {model} @ {host} con Home Assistant?"
-            },
-            "credentials": {
-                "data": {
-                    "password": "Password del controller Smart Home"
-                }
-            },
-            "reauth_confirm": {
-                "description": "L'integrazione bosch_shc deve autenticare nuovamente il tuo account",
-                "title": "Autentica nuovamente l'integrazione"
-            },
-            "user": {
-                "data": {
-                    "host": "Host"
-                },
-                "description": "Configura il tuo Bosch Smart Home Controller per consentire il monitoraggio e il controllo con Home Assistant.",
-                "title": "Parametri di autenticazione SHC"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automatico",
+              "manual": "Manuale",
+              "eco": "Eco",
+              "boost": "Boost"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Il dispositivo è già configurato",
+      "reauth_successful": "La nuova autenticazione è stata eseguita correttamente"
+    },
+    "error": {
+      "cannot_connect": "Impossibile connettersi",
+      "invalid_auth": "Autenticazione non valida",
+      "pairing_failed": "Associazione non riuscita; verifica che il controller Bosch Smart Home sia in modalità di associazione (LED lampeggiante) e che la password sia corretta.",
+      "session_error": "Errore di sessione: l'API restituisce il risultato Non-OK.",
+      "unknown": "Errore imprevisto"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "Premi il pulsante sul lato anteriore del controller Bosch Smart Home finché il LED non inizia a lampeggiare.\nSei pronto per continuare a configurare {model} @ {host} con Home Assistant?"
+      },
+      "credentials": {
+        "data": {
+          "password": "Password del controller Smart Home"
+        }
+      },
+      "reauth_confirm": {
+        "description": "L'integrazione bosch_shc deve autenticare nuovamente il tuo account",
+        "title": "Autentica nuovamente l'integrazione"
+      },
+      "user": {
+        "data": {
+          "host": "Host"
+        },
+        "description": "Configura il tuo Bosch Smart Home Controller per consentire il monitoraggio e il controllo con Home Assistant.",
+        "title": "Parametri di autenticazione SHC"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/ja.json
+++ b/custom_components/bosch_shc/translations/ja.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "\u30c7\u30d0\u30a4\u30b9\u306f\u3059\u3067\u306b\u8a2d\u5b9a\u3055\u308c\u3066\u3044\u307e\u3059",
-            "reauth_successful": "\u518d\u8a8d\u8a3c\u306b\u6210\u529f\u3057\u307e\u3057\u305f"
-        },
-        "error": {
-            "cannot_connect": "\u63a5\u7d9a\u306b\u5931\u6557\u3057\u307e\u3057\u305f",
-            "invalid_auth": "\u7121\u52b9\u306a\u8a8d\u8a3c",
-            "pairing_failed": "\u30da\u30a2\u30ea\u30f3\u30b0\u306b\u5931\u6557\u3057\u307e\u3057\u305f\u3002Bosch Smart Home Controller\u304c\u30da\u30a2\u30ea\u30f3\u30b0\u30e2\u30fc\u30c9\u306b\u306a\u3063\u3066\u3044\u308b(LED\u304c\u70b9\u6ec5)\u3053\u3068\u3068\u3001\u30d1\u30b9\u30ef\u30fc\u30c9\u304c\u6b63\u3057\u3044\u304b\u3069\u3046\u304b\u3092\u78ba\u8a8d\u3057\u3066\u304f\u3060\u3055\u3044\u3002",
-            "session_error": "\u30bb\u30c3\u30b7\u30e7\u30f3\u30a8\u30e9\u30fc: API\u304c\u3001OK\u4ee5\u5916\u306e\u7d50\u679c\u3092\u8fd4\u3057\u307e\u3059\u3002",
-            "unknown": "\u4e88\u671f\u3057\u306a\u3044\u30a8\u30e9\u30fc"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "LED\u304c\u70b9\u6ec5\u3057\u59cb\u3081\u308b\u307e\u3067\u3001Bosch Smart Home Controller\u306e\u524d\u9762\u306b\u3042\u308b\u30dc\u30bf\u30f3\u3092\u62bc\u3057\u3066\u304f\u3060\u3055\u3044\u3002\nHome Assistant\u3067\u3001{model} @ {host} \u3092\u8a2d\u5b9a\u3059\u308b\u6e96\u5099\u306f\u3067\u304d\u307e\u3057\u305f\u304b\uff1f"
-            },
-            "credentials": {
-                "data": {
-                    "password": "Smart Home Controller\u306e\u30d1\u30b9\u30ef\u30fc\u30c9"
-                }
-            },
-            "reauth_confirm": {
-                "description": "Bosch_shc\u7d71\u5408\u3067\u306f\u3001\u30a2\u30ab\u30a6\u30f3\u30c8\u3092\u518d\u8a8d\u8a3c\u3059\u308b\u5fc5\u8981\u304c\u3042\u308a\u307e\u3059",
-                "title": "\u7d71\u5408\u306e\u518d\u8a8d\u8a3c"
-            },
-            "user": {
-                "data": {
-                    "host": "\u30db\u30b9\u30c8"
-                },
-                "description": "Bosch Smart Home Controller\u3092\u30bb\u30c3\u30c8\u30a2\u30c3\u30d7\u3057\u3066\u3001Home Assistant\u3067\u76e3\u8996\u304a\u3088\u3073\u5236\u5fa1\u3067\u304d\u308b\u3088\u3046\u306b\u3057\u307e\u3059\u3002",
-                "title": "SHC\u8a8d\u8a3c\u30d1\u30e9\u30e1\u30fc\u30bf\u30fc"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "自動",
+              "manual": "手動",
+              "eco": "エコ",
+              "boost": "ブースト"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "デバイスはすでに設定されています",
+      "reauth_successful": "再認証に成功しました"
+    },
+    "error": {
+      "cannot_connect": "接続に失敗しました",
+      "invalid_auth": "無効な認証",
+      "pairing_failed": "ペアリングに失敗しました。Bosch Smart Home Controllerがペアリングモードになっている(LEDが点滅)ことと、パスワードが正しいかどうかを確認してください。",
+      "session_error": "セッションエラー: APIが、OK以外の結果を返します。",
+      "unknown": "予期しないエラー"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "LEDが点滅し始めるまで、Bosch Smart Home Controllerの前面にあるボタンを押してください。\nHome Assistantで、{model} @ {host} を設定する準備はできましたか？"
+      },
+      "credentials": {
+        "data": {
+          "password": "Smart Home Controllerのパスワード"
+        }
+      },
+      "reauth_confirm": {
+        "description": "Bosch_shc統合では、アカウントを再認証する必要があります",
+        "title": "統合の再認証"
+      },
+      "user": {
+        "data": {
+          "host": "ホスト"
+        },
+        "description": "Bosch Smart Home Controllerをセットアップして、Home Assistantで監視および制御できるようにします。",
+        "title": "SHC認証パラメーター"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/ko.json
+++ b/custom_components/bosch_shc/translations/ko.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "\uae30\uae30\uac00 \uc774\ubbf8 \uad6c\uc131\ub418\uc5c8\uc2b5\ub2c8\ub2e4",
-            "reauth_successful": "\uc7ac\uc778\uc99d\uc5d0 \uc131\uacf5\ud588\uc2b5\ub2c8\ub2e4"
-        },
-        "error": {
-            "cannot_connect": "\uc5f0\uacb0\ud558\uc9c0 \ubabb\ud588\uc2b5\ub2c8\ub2e4",
-            "invalid_auth": "\uc778\uc99d\uc774 \uc798\ubabb\ub418\uc5c8\uc2b5\ub2c8\ub2e4",
-            "pairing_failed": "\ud398\uc5b4\ub9c1\uc5d0 \uc2e4\ud328\ud588\uc2b5\ub2c8\ub2e4. Bosch Smart Home Controller\uac00 \ud398\uc5b4\ub9c1 \ubaa8\ub4dc(LED \uae5c\ubc15\uc784)\uc774\uace0 \ube44\ubc00\ubc88\ud638\uac00 \uc62c\ubc14\ub978\uc9c0 \ud655\uc778\ud558\uc2ed\uc2dc\uc624.",
-            "session_error": "\uc138\uc158 \uc624\ub958: API\uac00 \ube44\uc815\uc0c1 \uacb0\uacfc\ub97c \ubc18\ud658\ud569\ub2c8\ub2e4.",
-            "unknown": "\uc608\uc0c1\uce58 \ubabb\ud55c \uc624\ub958\uac00 \ubc1c\uc0dd\ud588\uc2b5\ub2c8\ub2e4"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "LED\uac00 \uae5c\ubc15\uc774\uae30 \uc2dc\uc791\ud560 \ub54c\uae4c\uc9c0 Bosch Smart Home Controller\uc758 \uc804\uba74 \ubc84\ud2bc\uc744 \ub204\ub974\uc2ed\uc2dc\uc624.\nHome Assistant\ub85c {model} @ {host} \ub97c \uacc4\uc18d \uc124\uc815\ud560 \uc900\ube44\uac00 \ub418\uc168\uc2b5\ub2c8\uae4c?"
-            },
-            "credentials": {
-                "data": {
-                    "password": "Smart Home Controller\uc758 \ube44\ubc00\ubc88\ud638"
-                }
-            },
-            "reauth_confirm": {
-                "description": "bosch_shc \ud1b5\ud569\uad6c\uc131\uc694\uc18c\ub294 \uacc4\uc815\uc744 \ub2e4\uc2dc \uc778\uc99d\ud574\uc57c \ud569\ub2c8\ub2e4.",
-                "title": "\ud1b5\ud569 \uad6c\uc131\uc694\uc18c \uc7ac\uc778\uc99d\ud558\uae30"
-            },
-            "user": {
-                "data": {
-                    "host": "\ud638\uc2a4\ud2b8"
-                },
-                "description": "Home Assistant\ub85c \ubaa8\ub2c8\ud130\ub9c1\ud558\uace0 \uc81c\uc5b4\ud560 \uc218 \uc788\ub3c4\ub85d Bosch Smart Home Controller\ub97c \uc124\uc815\ud558\uc2ed\uc2dc\uc624.",
-                "title": "SHC \uc778\uc99d \ub9e4\uac1c\ubcc0\uc218"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "자동",
+              "manual": "수동",
+              "eco": "에코",
+              "boost": "부스트"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "기기가 이미 구성되었습니다",
+      "reauth_successful": "재인증에 성공했습니다"
+    },
+    "error": {
+      "cannot_connect": "연결하지 못했습니다",
+      "invalid_auth": "인증이 잘못되었습니다",
+      "pairing_failed": "페어링에 실패했습니다. Bosch Smart Home Controller가 페어링 모드(LED 깜박임)이고 비밀번호가 올바른지 확인하십시오.",
+      "session_error": "세션 오류: API가 비정상 결과를 반환합니다.",
+      "unknown": "예상치 못한 오류가 발생했습니다"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "LED가 깜박이기 시작할 때까지 Bosch Smart Home Controller의 전면 버튼을 누르십시오.\nHome Assistant로 {model} @ {host} 를 계속 설정할 준비가 되셨습니까?"
+      },
+      "credentials": {
+        "data": {
+          "password": "Smart Home Controller의 비밀번호"
+        }
+      },
+      "reauth_confirm": {
+        "description": "bosch_shc 통합구성요소는 계정을 다시 인증해야 합니다.",
+        "title": "통합 구성요소 재인증하기"
+      },
+      "user": {
+        "data": {
+          "host": "호스트"
+        },
+        "description": "Home Assistant로 모니터링하고 제어할 수 있도록 Bosch Smart Home Controller를 설정하십시오.",
+        "title": "SHC 인증 매개변수"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/lv.json
+++ b/custom_components/bosch_shc/translations/lv.json
@@ -1,7 +1,23 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Ier\u012bce jau pievienota Home Assistant."
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automātisks",
+              "manual": "Manuāls",
+              "eco": "Eco",
+              "boost": "Boost"
+            }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Ierīce jau pievienota Home Assistant."
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/nb.json
+++ b/custom_components/bosch_shc/translations/nb.json
@@ -1,7 +1,23 @@
 {
-    "config": {
-        "error": {
-            "unknown": "Uventet feil"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automatisk",
+              "manual": "Manuell",
+              "eco": "Eco",
+              "boost": "Boost"
+            }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "error": {
+      "unknown": "Uventet feil"
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/nl.json
+++ b/custom_components/bosch_shc/translations/nl.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Apparaat is al geconfigureerd",
-            "reauth_successful": "Herauthenticatie geslaagd"
-        },
-        "error": {
-            "cannot_connect": "Kan geen verbinding maken",
-            "invalid_auth": "Ongeldige authenticatie",
-            "pairing_failed": "Koppelen mislukt; Controleer of de Bosch Smart Home Controller zich in de koppelingsmodus bevindt (LED knippert) en of uw wachtwoord correct is.",
-            "session_error": "Sessiefout: API retourneert niet-OK resultaat.",
-            "unknown": "Onverwachte fout"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "Druk op de knop aan de voorzijde van de Bosch Smart Home Controller totdat de LED begint te knipperen.\nKlaar om verder te gaan met het instellen van {model} @ {host} met Home Assistant?"
-            },
-            "credentials": {
-                "data": {
-                    "password": "Wachtwoord van de Smart Home Controller"
-                }
-            },
-            "reauth_confirm": {
-                "description": "De bosch_shc integratie moet uw account herauthenticeren",
-                "title": "Integratie herauthenticeren"
-            },
-            "user": {
-                "data": {
-                    "host": "Host"
-                },
-                "description": "Stel uw Bosch Smart Home Controller in om monitoring en bediening met Home Assistant mogelijk te maken.",
-                "title": "SHC-authenticatieparameters"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automatisch",
+              "manual": "Handmatig",
+              "eco": "Eco",
+              "boost": "Boost"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Apparaat is al geconfigureerd",
+      "reauth_successful": "Herauthenticatie geslaagd"
+    },
+    "error": {
+      "cannot_connect": "Kan geen verbinding maken",
+      "invalid_auth": "Ongeldige authenticatie",
+      "pairing_failed": "Koppelen mislukt; Controleer of de Bosch Smart Home Controller zich in de koppelingsmodus bevindt (LED knippert) en of uw wachtwoord correct is.",
+      "session_error": "Sessiefout: API retourneert niet-OK resultaat.",
+      "unknown": "Onverwachte fout"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "Druk op de knop aan de voorzijde van de Bosch Smart Home Controller totdat de LED begint te knipperen.\nKlaar om verder te gaan met het instellen van {model} @ {host} met Home Assistant?"
+      },
+      "credentials": {
+        "data": {
+          "password": "Wachtwoord van de Smart Home Controller"
+        }
+      },
+      "reauth_confirm": {
+        "description": "De bosch_shc integratie moet uw account herauthenticeren",
+        "title": "Integratie herauthenticeren"
+      },
+      "user": {
+        "data": {
+          "host": "Host"
+        },
+        "description": "Stel uw Bosch Smart Home Controller in om monitoring en bediening met Home Assistant mogelijk te maken.",
+        "title": "SHC-authenticatieparameters"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/no.json
+++ b/custom_components/bosch_shc/translations/no.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Enheten er allerede konfigurert",
-            "reauth_successful": "Re-autentisering var vellykket"
-        },
-        "error": {
-            "cannot_connect": "Tilkobling mislyktes",
-            "invalid_auth": "Ugyldig godkjenning",
-            "pairing_failed": "Paringen mislyktes. Kontroller at Bosch Smart Home Controller er i sammenkoblingsmodus (LED blinker) s\u00e5 vel som passordet ditt er riktig.",
-            "session_error": "\u00d8ktfeil: API returnerer ikke OK-resultat.",
-            "unknown": "Uventet feil"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "Trykk p\u00e5 Bosch Smart Home Controller-frontknappen til LED-lampen begynner \u00e5 blinke.\n Klar til \u00e5 fortsette \u00e5 konfigurere {model} @ {host} med Home Assistant?"
-            },
-            "credentials": {
-                "data": {
-                    "password": "Passordet til Smart Home Controller"
-                }
-            },
-            "reauth_confirm": {
-                "description": "Bosch_shc-integrasjonen m\u00e5 godkjenne kontoen din p\u00e5 nytt",
-                "title": "Godkjenne integrering p\u00e5 nytt"
-            },
-            "user": {
-                "data": {
-                    "host": "Vert"
-                },
-                "description": "Sett opp din Bosch Smart Home Controller for \u00e5 tillate overv\u00e5king og kontroll med Home Assistant.",
-                "title": "SHC-autentiseringsparametere"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automatisk",
+              "manual": "Manuell",
+              "eco": "Eco",
+              "boost": "Boost"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Enheten er allerede konfigurert",
+      "reauth_successful": "Re-autentisering var vellykket"
+    },
+    "error": {
+      "cannot_connect": "Tilkobling mislyktes",
+      "invalid_auth": "Ugyldig godkjenning",
+      "pairing_failed": "Paringen mislyktes. Kontroller at Bosch Smart Home Controller er i sammenkoblingsmodus (LED blinker) så vel som passordet ditt er riktig.",
+      "session_error": "Øktfeil: API returnerer ikke OK-resultat.",
+      "unknown": "Uventet feil"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "Trykk på Bosch Smart Home Controller-frontknappen til LED-lampen begynner å blinke.\n Klar til å fortsette å konfigurere {model} @ {host} med Home Assistant?"
+      },
+      "credentials": {
+        "data": {
+          "password": "Passordet til Smart Home Controller"
+        }
+      },
+      "reauth_confirm": {
+        "description": "Bosch_shc-integrasjonen må godkjenne kontoen din på nytt",
+        "title": "Godkjenne integrering på nytt"
+      },
+      "user": {
+        "data": {
+          "host": "Vert"
+        },
+        "description": "Sett opp din Bosch Smart Home Controller for å tillate overvåking og kontroll med Home Assistant.",
+        "title": "SHC-autentiseringsparametere"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/pl.json
+++ b/custom_components/bosch_shc/translations/pl.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Urz\u0105dzenie jest ju\u017c skonfigurowane",
-            "reauth_successful": "Ponowne uwierzytelnienie powiod\u0142o si\u0119"
-        },
-        "error": {
-            "cannot_connect": "Nie mo\u017cna nawi\u0105za\u0107 po\u0142\u0105czenia",
-            "invalid_auth": "Niepoprawne uwierzytelnienie",
-            "pairing_failed": "Parowanie nie powiod\u0142o si\u0119. Sprawd\u017a, czy kontroler Bosch Smart Home jest w trybie parowania (miga dioda LED) i czy Twoje has\u0142o jest prawid\u0142owe.",
-            "session_error": "B\u0142\u0105d sesji: API zwr\u00f3ci\u0142o niepoprawny wynik.",
-            "unknown": "Nieoczekiwany b\u0142\u0105d"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "Naci\u015bnij przycisk z przodu kontrolera Bosch Smart Home, a\u017c dioda LED zacznie miga\u0107. Chcesz kontynuowa\u0107 konfiguracj\u0119 {model} @ {host} z Home Assistantem?"
-            },
-            "credentials": {
-                "data": {
-                    "password": "Has\u0142o"
-                }
-            },
-            "reauth_confirm": {
-                "description": "Integracja Bosch_SHC wymaga ponownego uwierzytelnienia Twojego konta",
-                "title": "Ponownie uwierzytelnij integracj\u0119"
-            },
-            "user": {
-                "data": {
-                    "host": "Nazwa hosta lub adres IP"
-                },
-                "description": "Skonfiguruj kontroler Bosch Smart Home, aby umo\u017cliwi\u0107 monitorowanie i sterowanie za pomoc\u0105 Home Assistanta.",
-                "title": "Parametry uwierzytelniania SHC"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automatyczny",
+              "manual": "Ręczny",
+              "eco": "Eco",
+              "boost": "Boost"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Urządzenie jest już skonfigurowane",
+      "reauth_successful": "Ponowne uwierzytelnienie powiodło się"
+    },
+    "error": {
+      "cannot_connect": "Nie można nawiązać połączenia",
+      "invalid_auth": "Niepoprawne uwierzytelnienie",
+      "pairing_failed": "Parowanie nie powiodło się. Sprawdź, czy kontroler Bosch Smart Home jest w trybie parowania (miga dioda LED) i czy Twoje hasło jest prawidłowe.",
+      "session_error": "Błąd sesji: API zwróciło niepoprawny wynik.",
+      "unknown": "Nieoczekiwany błąd"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "Naciśnij przycisk z przodu kontrolera Bosch Smart Home, aż dioda LED zacznie migać. Chcesz kontynuować konfigurację {model} @ {host} z Home Assistantem?"
+      },
+      "credentials": {
+        "data": {
+          "password": "Hasło"
+        }
+      },
+      "reauth_confirm": {
+        "description": "Integracja Bosch_SHC wymaga ponownego uwierzytelnienia Twojego konta",
+        "title": "Ponownie uwierzytelnij integrację"
+      },
+      "user": {
+        "data": {
+          "host": "Nazwa hosta lub adres IP"
+        },
+        "description": "Skonfiguruj kontroler Bosch Smart Home, aby umożliwić monitorowanie i sterowanie za pomocą Home Assistanta.",
+        "title": "Parametry uwierzytelniania SHC"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/pt-BR.json
+++ b/custom_components/bosch_shc/translations/pt-BR.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Dispositivo j\u00e1 est\u00e1 configurado",
-            "reauth_successful": "A reautentica\u00e7\u00e3o foi bem-sucedida"
-        },
-        "error": {
-            "cannot_connect": "Falha ao conectar",
-            "invalid_auth": "Autentica\u00e7\u00e3o inv\u00e1lida",
-            "pairing_failed": "Falha no emparelhamento; verifique se o Bosch Smart Home Controller est\u00e1 no modo de emparelhamento (LED piscando) e se sua senha est\u00e1 correta.",
-            "session_error": "Erro de sess\u00e3o: API retorna resultado n\u00e3o OK.",
-            "unknown": "Erro inesperado"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "Pressione o bot\u00e3o frontal do Bosch Smart Home Controller at\u00e9 que o LED comece a piscar.\n Pronto para continuar a configurar {model} @ {host} com o Home Assistant?"
-            },
-            "credentials": {
-                "data": {
-                    "password": "Senha do Smart Home Controller"
-                }
-            },
-            "reauth_confirm": {
-                "description": "A integra\u00e7\u00e3o bosch_shc precisa re-autenticar sua conta",
-                "title": "Reautenticar Integra\u00e7\u00e3o"
-            },
-            "user": {
-                "data": {
-                    "host": "Nome do host"
-                },
-                "description": "Configure seu Bosch Smart Home Controller para permitir monitoramento e controle com o Home Assistant.",
-                "title": "Par\u00e2metros de autentica\u00e7\u00e3o SHC"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automático",
+              "manual": "Manual",
+              "eco": "Eco",
+              "boost": "Boost"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Dispositivo já está configurado",
+      "reauth_successful": "A reautenticação foi bem-sucedida"
+    },
+    "error": {
+      "cannot_connect": "Falha ao conectar",
+      "invalid_auth": "Autenticação inválida",
+      "pairing_failed": "Falha no emparelhamento; verifique se o Bosch Smart Home Controller está no modo de emparelhamento (LED piscando) e se sua senha está correta.",
+      "session_error": "Erro de sessão: API retorna resultado não OK.",
+      "unknown": "Erro inesperado"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "Pressione o botão frontal do Bosch Smart Home Controller até que o LED comece a piscar.\n Pronto para continuar a configurar {model} @ {host} com o Home Assistant?"
+      },
+      "credentials": {
+        "data": {
+          "password": "Senha do Smart Home Controller"
+        }
+      },
+      "reauth_confirm": {
+        "description": "A integração bosch_shc precisa re-autenticar sua conta",
+        "title": "Reautenticar Integração"
+      },
+      "user": {
+        "data": {
+          "host": "Nome do host"
+        },
+        "description": "Configure seu Bosch Smart Home Controller para permitir monitoramento e controle com o Home Assistant.",
+        "title": "Parâmetros de autenticação SHC"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/pt.json
+++ b/custom_components/bosch_shc/translations/pt.json
@@ -1,23 +1,39 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "O dispositivo j\u00e1 est\u00e1 configurado",
-            "reauth_successful": "Reautentica\u00e7\u00e3o bem sucedida"
-        },
-        "error": {
-            "cannot_connect": "A liga\u00e7\u00e3o falhou",
-            "invalid_auth": "Autentica\u00e7\u00e3o inv\u00e1lida",
-            "unknown": "Erro inesperado"
-        },
-        "step": {
-            "reauth_confirm": {
-                "title": "Reautenticar integra\u00e7\u00e3o"
-            },
-            "user": {
-                "data": {
-                    "host": "Endere\u00e7o"
-                }
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automático",
+              "manual": "Manual",
+              "eco": "Eco",
+              "boost": "Boost"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "O dispositivo já está configurado",
+      "reauth_successful": "Reautenticação bem sucedida"
+    },
+    "error": {
+      "cannot_connect": "A ligação falhou",
+      "invalid_auth": "Autenticação inválida",
+      "unknown": "Erro inesperado"
+    },
+    "step": {
+      "reauth_confirm": {
+        "title": "Reautenticar integração"
+      },
+      "user": {
+        "data": {
+          "host": "Endereço"
+        }
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/ru.json
+++ b/custom_components/bosch_shc/translations/ru.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "\u042d\u0442\u043e \u0443\u0441\u0442\u0440\u043e\u0439\u0441\u0442\u0432\u043e \u0443\u0436\u0435 \u0434\u043e\u0431\u0430\u0432\u043b\u0435\u043d\u043e \u0432 Home Assistant.",
-            "reauth_successful": "\u041f\u043e\u0432\u0442\u043e\u0440\u043d\u0430\u044f \u0430\u0443\u0442\u0435\u043d\u0442\u0438\u0444\u0438\u043a\u0430\u0446\u0438\u044f \u0432\u044b\u043f\u043e\u043b\u043d\u0435\u043d\u0430 \u0443\u0441\u043f\u0435\u0448\u043d\u043e."
-        },
-        "error": {
-            "cannot_connect": "\u041d\u0435 \u0443\u0434\u0430\u043b\u043e\u0441\u044c \u043f\u043e\u0434\u043a\u043b\u044e\u0447\u0438\u0442\u044c\u0441\u044f.",
-            "invalid_auth": "\u041e\u0448\u0438\u0431\u043a\u0430 \u0430\u0443\u0442\u0435\u043d\u0442\u0438\u0444\u0438\u043a\u0430\u0446\u0438\u0438.",
-            "pairing_failed": "\u0421\u043e\u043f\u0440\u044f\u0436\u0435\u043d\u0438\u0435 \u043d\u0435 \u0443\u0434\u0430\u043b\u043e\u0441\u044c. \u0423\u0431\u0435\u0434\u0438\u0442\u0435\u0441\u044c, \u0447\u0442\u043e \u043a\u043e\u043d\u0442\u0440\u043e\u043b\u043b\u0435\u0440 Bosch Smart Home Controller \u043d\u0430\u0445\u043e\u0434\u0438\u0442\u0441\u044f \u0432 \u0440\u0435\u0436\u0438\u043c\u0435 \u0441\u043e\u043f\u0440\u044f\u0436\u0435\u043d\u0438\u044f (\u0441\u0432\u0435\u0442\u043e\u0434\u0438\u043e\u0434\u043d\u044b\u0439 \u0438\u043d\u0434\u0438\u043a\u0430\u0442\u043e\u0440 \u043c\u0438\u0433\u0430\u0435\u0442) \u0438 \u0447\u0442\u043e \u0443\u043a\u0430\u0437\u0430\u043d\u043d\u044b\u0439 \u043f\u0430\u0440\u043e\u043b\u044c \u043f\u0440\u0430\u0432\u0438\u043b\u044c\u043d\u044b\u0439.",
-            "session_error": "\u041e\u0448\u0438\u0431\u043a\u0430 \u0441\u0435\u0430\u043d\u0441\u0430: API \u0432\u043e\u0437\u0432\u0440\u0430\u0449\u0430\u0435\u0442 \u0440\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442 Non-OK.",
-            "unknown": "\u041d\u0435\u043f\u0440\u0435\u0434\u0432\u0438\u0434\u0435\u043d\u043d\u0430\u044f \u043e\u0448\u0438\u0431\u043a\u0430."
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "\u0423\u0434\u0435\u0440\u0436\u0438\u0432\u0430\u0439\u0442\u0435 \u043a\u043d\u043e\u043f\u043a\u0443 \u043d\u0430 \u043f\u0435\u0440\u0435\u0434\u043d\u0435\u0439 \u043f\u0430\u043d\u0435\u043b\u0438 \u043a\u043e\u043d\u0442\u0440\u043e\u043b\u043b\u0435\u0440\u0430, \u043f\u043e\u043a\u0430 \u0441\u0432\u0435\u0442\u043e\u0434\u0438\u043e\u0434\u043d\u044b\u0435 \u0438\u043d\u0434\u0438\u043a\u0430\u0442\u043e\u0440\u044b \u043d\u0435 \u043d\u0430\u0447\u043d\u0443\u0442 \u043c\u0438\u0433\u0430\u0442\u044c.\n\u0413\u043e\u0442\u043e\u0432\u044b \u043f\u0440\u043e\u0434\u043e\u043b\u0436\u0438\u0442\u044c \u043d\u0430\u0441\u0442\u0440\u043e\u0439\u043a\u0443 Home Assistant \u0434\u043b\u044f \u0438\u043d\u0442\u0435\u0433\u0440\u0430\u0446\u0438\u0438 \u0441 {model} @ {host}?"
-            },
-            "credentials": {
-                "data": {
-                    "password": "\u041f\u0430\u0440\u043e\u043b\u044c Smart Home Controller"
-                }
-            },
-            "reauth_confirm": {
-                "description": "\u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044f \u043f\u043e\u0432\u0442\u043e\u0440\u043d\u0430\u044f \u0430\u0443\u0442\u0435\u043d\u0442\u0438\u0444\u0438\u043a\u0430\u0446\u0438\u044f \u0443\u0447\u0435\u0442\u043d\u043e\u0439 \u0437\u0430\u043f\u0438\u0441\u0438 Bosch SHC",
-                "title": "\u041f\u043e\u0432\u0442\u043e\u0440\u043d\u0430\u044f \u0430\u0443\u0442\u0435\u043d\u0442\u0438\u0444\u0438\u043a\u0430\u0446\u0438\u044f"
-            },
-            "user": {
-                "data": {
-                    "host": "\u0425\u043e\u0441\u0442"
-                },
-                "description": "\u041d\u0430\u0441\u0442\u0440\u043e\u0439\u043a\u0430 Home Assistant \u0434\u043b\u044f \u0438\u043d\u0442\u0435\u0433\u0440\u0430\u0446\u0438\u0438 \u0441 Bosch Smart Home Controller.",
-                "title": "\u041f\u0430\u0440\u0430\u043c\u0435\u0442\u0440\u044b \u0430\u0443\u0442\u0435\u043d\u0442\u0438\u0444\u0438\u043a\u0430\u0446\u0438\u0438 SHC"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Автоматический",
+              "manual": "Ручной",
+              "eco": "Эко",
+              "boost": "Буст"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Это устройство уже добавлено в Home Assistant.",
+      "reauth_successful": "Повторная аутентификация выполнена успешно."
+    },
+    "error": {
+      "cannot_connect": "Не удалось подключиться.",
+      "invalid_auth": "Ошибка аутентификации.",
+      "pairing_failed": "Сопряжение не удалось. Убедитесь, что контроллер Bosch Smart Home Controller находится в режиме сопряжения (светодиодный индикатор мигает) и что указанный пароль правильный.",
+      "session_error": "Ошибка сеанса: API возвращает результат Non-OK.",
+      "unknown": "Непредвиденная ошибка."
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "Удерживайте кнопку на передней панели контроллера, пока светодиодные индикаторы не начнут мигать.\nГотовы продолжить настройку Home Assistant для интеграции с {model} @ {host}?"
+      },
+      "credentials": {
+        "data": {
+          "password": "Пароль Smart Home Controller"
+        }
+      },
+      "reauth_confirm": {
+        "description": "Требуется повторная аутентификация учетной записи Bosch SHC",
+        "title": "Повторная аутентификация"
+      },
+      "user": {
+        "data": {
+          "host": "Хост"
+        },
+        "description": "Настройка Home Assistant для интеграции с Bosch Smart Home Controller.",
+        "title": "Параметры аутентификации SHC"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/sk.json
+++ b/custom_components/bosch_shc/translations/sk.json
@@ -1,40 +1,56 @@
 {
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automaticky",
+              "manual": "Ručne",
+              "eco": "Eco",
+              "boost": "Boost"
+            }
+          }
+        }
+      }
+    }
+  },
   "config": {
     "abort": {
-      "already_configured": "Zariadenie u\u017e je nakonfigurovan\u00e9",
-      "reauth_successful": "Op\u00e4tovn\u00e9 overenie bolo \u00faspe\u0161n\u00e9"
+      "already_configured": "Zariadenie už je nakonfigurované",
+      "reauth_successful": "Opätovné overenie bolo úspešné"
     },
     "error": {
-      "cannot_connect": "Nepodarilo sa pripoji\u0165",
-      "invalid_auth": "Neplatn\u00e9 overenie",
-      "pairing_failed": "P\u00e1rovanie zlyhalo; skontrolujte, \u010di je ovl\u00e1da\u010d Bosch Smart Home Controller v re\u017eime p\u00e1rovania (LED blik\u00e1) a \u010di je va\u0161e heslo spr\u00e1vne.",
-      "session_error": "Chyba rel\u00e1cie: API vr\u00e1tilo v\u00fdsledok Non-OK.",
-      "unknown": "Neo\u010dak\u00e1van\u00e1 chyba"
+      "cannot_connect": "Nepodarilo sa pripojiť",
+      "invalid_auth": "Neplatné overenie",
+      "pairing_failed": "Párovanie zlyhalo; skontrolujte, či je ovládač Bosch Smart Home Controller v režime párovania (LED bliká) a či je vaše heslo správne.",
+      "session_error": "Chyba relácie: API vrátilo výsledok Non-OK.",
+      "unknown": "Neočakávaná chyba"
     },
     "flow_title": "Bosch SHC: {name}",
     "step": {
       "confirm_discovery": {
-        "description": "Stla\u010dte tla\u010didlo na prednej strane ovl\u00e1da\u010da Bosch Smart Home Controller, k\u00fdm LED neza\u010dne blika\u0165.\n Ste pripraven\u00ed pokra\u010dova\u0165 v nastavovan\u00ed {model} @ {host} pomocou Home Assistant?"
+        "description": "Stlačte tlačidlo na prednej strane ovládača Bosch Smart Home Controller, kým LED nezačne blikať.\n Ste pripravení pokračovať v nastavovaní {model} @ {host} pomocou Home Assistant?"
       },
       "credentials": {
         "data": {
-          "password": "Heslo ovl\u00e1da\u010da Smart Home Controller",
+          "password": "Heslo ovládača Smart Home Controller",
           "name": "Meno klienta pre certifikát"
         }
       },
       "reauth_confirm": {
-        "description": "Integr\u00e1cia bosch_shc mus\u00ed znova overi\u0165 v\u00e1\u0161 \u00fa\u010det",
-        "title": "Znova overi\u0165 integr\u00e1ciu",
+        "description": "Integrácia bosch_shc musí znova overiť váš účet",
+        "title": "Znova overiť integráciu",
         "data": {
           "host": "Host"
         }
       },
       "user": {
         "data": {
-          "host": "Hostite\u013e"
+          "host": "Hostiteľ"
         },
-        "description": "Nastavte svoj ovl\u00e1da\u010d Bosch Smart Home Controller tak, aby umo\u017e\u0148oval monitorovanie a ovl\u00e1danie pomocou Home Assistant.",
-        "title": "Parametre autentifik\u00e1cie SHC"
+        "description": "Nastavte svoj ovládač Bosch Smart Home Controller tak, aby umožňoval monitorovanie a ovládanie pomocou Home Assistant.",
+        "title": "Parametre autentifikácie SHC"
       }
     }
   },

--- a/custom_components/bosch_shc/translations/sv.json
+++ b/custom_components/bosch_shc/translations/sv.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Enheten \u00e4r redan konfigurerad",
-            "reauth_successful": "\u00c5terautentisering lyckades"
-        },
-        "error": {
-            "cannot_connect": "Det gick inte att ansluta.",
-            "invalid_auth": "Ogiltig autentisering",
-            "pairing_failed": "Kopplingen misslyckades; kontrollera att Bosch Smart Home Controller \u00e4r i kopplingsl\u00e4ge (lysdioden blinkar) och att ditt l\u00f6senord \u00e4r korrekt.",
-            "session_error": "Sessionsfel: API returnerar resultat som inte \u00e4r OK.",
-            "unknown": "Ov\u00e4ntat fel"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "Tryck p\u00e5 knappen p\u00e5 framsidan av Bosch Smart Home Controller tills lysdioden b\u00f6rjar blinka.\nRedo att forts\u00e4tta att st\u00e4lla in {modell} @ {host} med Home Assistant?"
-            },
-            "credentials": {
-                "data": {
-                    "password": "L\u00f6senord f\u00f6r Smart Home Controller"
-                }
-            },
-            "reauth_confirm": {
-                "description": "Bosch_shc-integrationen m\u00e5ste autentisera ditt konto igen",
-                "title": "\u00c5terautenticera integration"
-            },
-            "user": {
-                "data": {
-                    "host": "V\u00e4rd"
-                },
-                "description": "St\u00e4ll in din Bosch Smart Home Controller f\u00f6r att till\u00e5ta \u00f6vervakning och kontroll med Home Assistant.",
-                "title": "SHC-autentiseringsparametrar"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automatisk",
+              "manual": "Manuell",
+              "eco": "Eco",
+              "boost": "Boost"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Enheten är redan konfigurerad",
+      "reauth_successful": "Återautentisering lyckades"
+    },
+    "error": {
+      "cannot_connect": "Det gick inte att ansluta.",
+      "invalid_auth": "Ogiltig autentisering",
+      "pairing_failed": "Kopplingen misslyckades; kontrollera att Bosch Smart Home Controller är i kopplingsläge (lysdioden blinkar) och att ditt lösenord är korrekt.",
+      "session_error": "Sessionsfel: API returnerar resultat som inte är OK.",
+      "unknown": "Oväntat fel"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "Tryck på knappen på framsidan av Bosch Smart Home Controller tills lysdioden börjar blinka.\nRedo att fortsätta att ställa in {modell} @ {host} med Home Assistant?"
+      },
+      "credentials": {
+        "data": {
+          "password": "Lösenord för Smart Home Controller"
+        }
+      },
+      "reauth_confirm": {
+        "description": "Bosch_shc-integrationen måste autentisera ditt konto igen",
+        "title": "Återautenticera integration"
+      },
+      "user": {
+        "data": {
+          "host": "Värd"
+        },
+        "description": "Ställ in din Bosch Smart Home Controller för att tillåta övervakning och kontroll med Home Assistant.",
+        "title": "SHC-autentiseringsparametrar"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/tr.json
+++ b/custom_components/bosch_shc/translations/tr.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Cihaz zaten yap\u0131land\u0131r\u0131lm\u0131\u015f",
-            "reauth_successful": "Yeniden kimlik do\u011frulama ba\u015far\u0131l\u0131 oldu"
-        },
-        "error": {
-            "cannot_connect": "Ba\u011flanma hatas\u0131",
-            "invalid_auth": "Ge\u00e7ersiz kimlik do\u011frulama",
-            "pairing_failed": "E\u015fle\u015ftirme ba\u015far\u0131s\u0131z; l\u00fctfen Bosch Ak\u0131ll\u0131 Ev Kumandas\u0131n\u0131n e\u015fle\u015ftirme modunda (LED yan\u0131p s\u00f6n\u00fcyor) ve \u015fifrenizin do\u011fru oldu\u011funu kontrol edin.",
-            "session_error": "Oturum hatas\u0131: API, Tamam Olmayan sonucu d\u00f6nd\u00fcr\u00fcr.",
-            "unknown": "Beklenmeyen hata"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "L\u00fctfen LED yan\u0131p s\u00f6nmeye ba\u015flayana kadar Bosch Ak\u0131ll\u0131 Ev Denetleyicisinin \u00f6n taraf\u0131ndaki d\u00fc\u011fmeye bas\u0131n.\n Home Assistant ile {model} @ {host} kurulumuna devam etmeye haz\u0131r m\u0131s\u0131n\u0131z?"
-            },
-            "credentials": {
-                "data": {
-                    "password": "Ak\u0131ll\u0131 Ev Denetleyicisinin \u015eifresi"
-                }
-            },
-            "reauth_confirm": {
-                "description": "bosch_shc entegrasyonunun hesab\u0131n\u0131z\u0131 yeniden do\u011frulamas\u0131 gerekiyor",
-                "title": "Entegrasyonu Yeniden Do\u011frula"
-            },
-            "user": {
-                "data": {
-                    "host": "Sunucu"
-                },
-                "description": "Ev Asistan\u0131 ile izleme ve kontrole izin vermek i\u00e7in Bosch Ak\u0131ll\u0131 Ev Denetleyicinizi kurun.",
-                "title": "SHC kimlik do\u011frulama parametreleri"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Otomatik",
+              "manual": "Manuel",
+              "eco": "Eco",
+              "boost": "Boost"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Cihaz zaten yapılandırılmış",
+      "reauth_successful": "Yeniden kimlik doğrulama başarılı oldu"
+    },
+    "error": {
+      "cannot_connect": "Bağlanma hatası",
+      "invalid_auth": "Geçersiz kimlik doğrulama",
+      "pairing_failed": "Eşleştirme başarısız; lütfen Bosch Akıllı Ev Kumandasının eşleştirme modunda (LED yanıp sönüyor) ve şifrenizin doğru olduğunu kontrol edin.",
+      "session_error": "Oturum hatası: API, Tamam Olmayan sonucu döndürür.",
+      "unknown": "Beklenmeyen hata"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "Lütfen LED yanıp sönmeye başlayana kadar Bosch Akıllı Ev Denetleyicisinin ön tarafındaki düğmeye basın.\n Home Assistant ile {model} @ {host} kurulumuna devam etmeye hazır mısınız?"
+      },
+      "credentials": {
+        "data": {
+          "password": "Akıllı Ev Denetleyicisinin Şifresi"
+        }
+      },
+      "reauth_confirm": {
+        "description": "bosch_shc entegrasyonunun hesabınızı yeniden doğrulaması gerekiyor",
+        "title": "Entegrasyonu Yeniden Doğrula"
+      },
+      "user": {
+        "data": {
+          "host": "Sunucu"
+        },
+        "description": "Ev Asistanı ile izleme ve kontrole izin vermek için Bosch Akıllı Ev Denetleyicinizi kurun.",
+        "title": "SHC kimlik doğrulama parametreleri"
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/uk.json
+++ b/custom_components/bosch_shc/translations/uk.json
@@ -1,11 +1,27 @@
 {
-    "config": {
-        "step": {
-            "credentials": {
-                "data": {
-                    "password": "\u041f\u0430\u0440\u043e\u043b\u044c Smart Home Controller"
-                }
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Автоматичний",
+              "manual": "Ручний",
+              "eco": "Еко",
+              "boost": "Буст"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "step": {
+      "credentials": {
+        "data": {
+          "password": "Пароль Smart Home Controller"
+        }
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/zh-Hans.json
+++ b/custom_components/bosch_shc/translations/zh-Hans.json
@@ -1,14 +1,30 @@
 {
-    "config": {
-        "error": {
-            "pairing_failed": "\u914d\u5bf9\u5931\u8d25\uff0c\u8bf7\u68c0\u67e5\u535a\u4e16 Smart Home Controller \u662f\u5426\u6b63\u5728\u5904\u4e8e\u914d\u5bf9\u6a21\u5f0f(LED \u706f\u95ea\u70c1)\uff0c\u4ee5\u53ca\u952e\u5165\u7684\u5bc6\u7801\u662f\u5426\u6b63\u786e"
-        },
-        "step": {
-            "credentials": {
-                "data": {
-                    "password": "Smart Home Controller \u5bc6\u7801"
-                }
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "自动",
+              "manual": "手动",
+              "eco": "节能",
+              "boost": "加速"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "error": {
+      "pairing_failed": "配对失败，请检查博世 Smart Home Controller 是否正在处于配对模式(LED 灯闪烁)，以及键入的密码是否正确"
+    },
+    "step": {
+      "credentials": {
+        "data": {
+          "password": "Smart Home Controller 密码"
+        }
+      }
+    }
+  }
 }

--- a/custom_components/bosch_shc/translations/zh-Hant.json
+++ b/custom_components/bosch_shc/translations/zh-Hant.json
@@ -1,37 +1,53 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "\u88dd\u7f6e\u5df2\u7d93\u8a2d\u5b9a\u5b8c\u6210",
-            "reauth_successful": "\u91cd\u65b0\u8a8d\u8b49\u6210\u529f"
-        },
-        "error": {
-            "cannot_connect": "\u9023\u7dda\u5931\u6557",
-            "invalid_auth": "\u9a57\u8b49\u78bc\u7121\u6548",
-            "pairing_failed": "\u914d\u5c0d\u5931\u6557\uff1a\u8acb\u78ba\u8a8d Bosch Smart Home Controller \u5df2\u7d93\u8655\u65bc\u914d\u5c0d\u6a21\u5f0f\uff08LED \u9583\u720d\uff09\u3001\u4e26\u4e14\u5bc6\u78bc\u8f38\u5165\u6b63\u78ba\u3002",
-            "session_error": "Session \u932f\u8aa4\uff1aAPI \u56de\u8986\u975e\u6b63\u5e38\u7d50\u679c\u3002",
-            "unknown": "\u672a\u9810\u671f\u932f\u8aa4"
-        },
-        "flow_title": "Bosch SHC: {name}",
-        "step": {
-            "confirm_discovery": {
-                "description": "\u8acb\u6309\u4e0b Bosch Smart Home Controller \u524d\u65b9\u7684\u6309\u9215\u76f4\u5230 LED \u9583\u720d\u3002\n\u662f\u5426\u8981\u7e7c\u7e8c\u8a2d\u5b9a\u4f4d\u65bc {host} \u7684 {model} \u9023\u63a5\u81f3 Home Assistant\uff1f"
-            },
-            "credentials": {
-                "data": {
-                    "password": "Smart Home Controller \u5bc6\u78bc"
-                }
-            },
-            "reauth_confirm": {
-                "description": "bosch_shc \u6574\u5408\u9700\u8981\u91cd\u65b0\u8a8d\u8b49\u60a8\u7684\u5e33\u865f",
-                "title": "\u91cd\u65b0\u8a8d\u8b49\u6574\u5408"
-            },
-            "user": {
-                "data": {
-                    "host": "\u4e3b\u6a5f\u7aef"
-                },
-                "description": "\u8a2d\u5b9a Bosch Smart Home Controller \u4ee5\u5141\u8a31 Home Assistant \u9032\u884c\u76e3\u63a7\u3002",
-                "title": "SHC \u8a8d\u8b49\u53c3\u6578"
+  "entity": {
+    "climate": {
+      "room_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "自動",
+              "manual": "手動",
+              "eco": "節能",
+              "boost": "加速"
             }
+          }
         }
+      }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "裝置已經設定完成",
+      "reauth_successful": "重新認證成功"
+    },
+    "error": {
+      "cannot_connect": "連線失敗",
+      "invalid_auth": "驗證碼無效",
+      "pairing_failed": "配對失敗：請確認 Bosch Smart Home Controller 已經處於配對模式（LED 閃爍）、並且密碼輸入正確。",
+      "session_error": "Session 錯誤：API 回覆非正常結果。",
+      "unknown": "未預期錯誤"
+    },
+    "flow_title": "Bosch SHC: {name}",
+    "step": {
+      "confirm_discovery": {
+        "description": "請按下 Bosch Smart Home Controller 前方的按鈕直到 LED 閃爍。\n是否要繼續設定位於 {host} 的 {model} 連接至 Home Assistant？"
+      },
+      "credentials": {
+        "data": {
+          "password": "Smart Home Controller 密碼"
+        }
+      },
+      "reauth_confirm": {
+        "description": "bosch_shc 整合需要重新認證您的帳號",
+        "title": "重新認證整合"
+      },
+      "user": {
+        "data": {
+          "host": "主機端"
+        },
+        "description": "設定 Bosch Smart Home Controller 以允許 Home Assistant 進行監控。",
+        "title": "SHC 認證參數"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Problem

The Bosch Room Climate Control exposes two orthogonal axes:
- **Direction** (`roomControlMode`): HEATING / COOLING / OFF
- **Regulation** (`operationMode`): AUTOMATIC / MANUAL

Home Assistant's `hvac_mode` is a single enum. The previous code squeezed both axes into it: `hvac_mode` read `cooling_mode` first and returned `COOL`, which made the AUTOMATIC/MANUAL regulation invisible while cooling — "cooling + automatic" was not representable. Setting `COOL` also never wrote `operation_mode`.

## Fix

| Bosch axis | HA mapping |
|---|---|
| Direction (roomControlMode) | `hvac_mode` → `heat` / `cool` / `off` |
| Regulation (operationMode) | `preset_mode` → `auto` / `manual` |
| Eco override (low) | `preset_mode` → `eco` (if `supports_eco`) |
| Boost override | `preset_mode` → `boost` (if `supports_boost_mode`) |

This is idiomatic HA and fully compatible with the Thermostat card, voice control, and automations.

## Changes

**`climate.py`** (`ClimateControl` only; `HeatingCircuit` is unchanged):
- `hvac_mode` reader: direction axis only (`heat`/`cool`/`off`), no more `auto`
- `hvac_modes`: order `[heat, (cool), off]` — active modes first, `off` last (HA convention; fixes Mushroom card swallowing the cool button when `off` appeared between active modes)
- `hvac_action`: direction-aware — reports `COOLING` when in cooling mode, not always `HEATING`
- `_supports_eco` (new property): `getattr(device, "supports_eco", True)` with fallback for older library versions
- `preset_mode`: returns `auto`/`manual` from `operation_mode`; `eco` gated on `_supports_eco`; `boost` takes display precedence while active
- `preset_modes`: `[auto, manual]` + `eco` if `_supports_eco` + `boost` if `supports_boost_mode`
- `async_set_hvac_mode`: sets direction only, does **not** touch `operation_mode`
- `async_set_preset_mode`: `auto`/`manual` write `operation_mode` and clear any eco/boost override; `eco`/`boost` set their override without changing the regulation

**`boschshcpy_patch.py`** (new, temporary):
Monkey-patches `supports_eco = True` onto `SHCClimateControl` at import time while the library property isn't released yet. To be removed (along with the two import lines in `climate.py`) once `manifest.json` requires a `boschshcpy` version that ships `supports_eco`.

**`icons.json`** (new):
Preset icons via `translation_key = "room_climate"`:
- `auto` → `mdi:clock-outline`
- `manual` → `mdi:hand-pointing-up`
- `eco` → `mdi:leaf`
- `boost` → `mdi:rocket-launch`

**Translations**:
All 30 language files get `entity.climate.room_climate.state_attributes.preset_mode.state` entries for `auto`/`manual`/`eco`/`boost`.

## Migration

> **Breaking change for Room Climate entities only. HeatingCircuit entities are unchanged.**

- `HVACMode.AUTO` is no longer a valid `hvac_mode` for Room Climate entities. Automations or scripts calling `climate.set_hvac_mode` with `"auto"` on these entities must switch to `climate.set_preset_mode` with `"auto"`.
- Dashboard cards that listed `"auto"` under `hvac_modes` for Room Climate should remove it.

## Dependency

Builds on a planned `boschshcpy` change adding `supports_eco`. The temporary shim (`boschshcpy_patch.py`) covers the gap until that library version is released and set as the minimum requirement in `manifest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)