### PR TITLE
Surface ruff/mypy findings as inline PR annotations

### DIFF
--- a/.github/matchers/mypy.json
+++ b/.github/matchers/mypy.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "mypy",
+      "pattern": [
+        {
+          "regexp": "^(.+?):(\\d+):(?:(\\d+):)?\\s+(error|warning|note):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -41,7 +41,9 @@ jobs:
           exit 1
 
       - name: ruff check (lint)
-        run: ruff check custom_components
+        # github format surfaces violations as inline PR annotations, same
+        # spot Copilot/CodeRabbit-style comments show up, no extra action needed.
+        run: ruff check --output-format=github custom_components
 
       - name: ruff format (format check)
         run: ruff format --check custom_components
@@ -74,7 +76,10 @@ jobs:
         run: pylint --rcfile=pyproject.toml custom_components/bosch_shc
 
       - name: Type check
-        run: mypy custom_components/bosch_shc/
+        run: |
+          echo "::add-matcher::.github/matchers/mypy.json"
+          mypy custom_components/bosch_shc/
+          echo "::remove-matcher owner=mypy::"
 
       - name: quality scale gate (platinum)
         run: python3 scripts/check-quality-scale.py --tier platinum


### PR DESCRIPTION
Copilot's automatic review on the home-assistant/core PRs has caught real bugs recently. We don't have an AI review bot on this repo yet (that needs a repo-owner action — see the linked comment), but this at least gets our existing ruff/mypy checks to show up as inline annotations on the diff instead of only in the raw job log:

- `ruff check` now uses its built-in `--output-format=github`
- `mypy` gets a GitHub Actions problem matcher (`.github/matchers/mypy.json`)

No new third-party actions or secrets, both are native GitHub Actions/tool features. Verified the annotation format locally against real ruff/mypy output before opening this.