### PR TITLE
Fix Light Control II never getting switch/actuator/output-mode selects

### DIFF
--- a/custom_components/bosch_shc/select.py
+++ b/custom_components/bosch_shc/select.py
@@ -279,35 +279,32 @@ async def async_setup_entry(  # noqa: C901
             )
 
     # SwitchConfiguration selects (MicromoduleRelay + LightControl).
+    # supports_switch_configuration only exists on SHCMicromoduleRelay (where
+    # it's simply "the switch-config service is present"); SHCLightControl has
+    # no such flag at all, so gating on it here silently produced zero
+    # switch/actuator/output-mode selects for every Light Control II, even
+    # though switch_type/actuator_type/output_mode are already null-safe
+    # (None when the underlying service isn't present) on both classes.
     for device in getattr(session.device_helper, "micromodule_relays", []) + getattr(
         session.device_helper, "micromodule_light_controls", []
     ):
         if device_excluded(device, config_entry.options):
             continue
-        if (
-            getattr(device, "supports_switch_configuration", False)
-            and getattr(device, "switch_type", None) is not None
-        ):
+        if getattr(device, "switch_type", None) is not None:
             entities.append(
                 SwitchTypeSelect(
                     device=device,
                     entry_id=config_entry.entry_id,
                 )
             )
-        if (
-            getattr(device, "supports_switch_configuration", False)
-            and getattr(device, "actuator_type", None) is not None
-        ):
+        if getattr(device, "actuator_type", None) is not None:
             entities.append(
                 ActuatorTypeSelect(
                     device=device,
                     entry_id=config_entry.entry_id,
                 )
             )
-        if (
-            getattr(device, "supports_switch_configuration", False)
-            and getattr(device, "output_mode", None) is not None
-        ):
+        if getattr(device, "output_mode", None) is not None:
             entities.append(
                 OutputModeSelect(
                     device=device,

--- a/tests/bosch_shc/test_apk_dual_guard_select.py
+++ b/tests/bosch_shc/test_apk_dual_guard_select.py
@@ -12,11 +12,20 @@ Entities covered:
   - ValveTypeSelect (supports_wall_thermostat_configuration + valve_type)
   - HeaterTypeSelect (supports_wall_thermostat_configuration + heater_type)
   - TerminalTypeSelect (supports_terminal_configuration + terminal_type)
-  - SwitchTypeSelect (supports_switch_configuration + switch_type)
-  - ActuatorTypeSelect (supports_switch_configuration + actuator_type)
-  - OutputModeSelect (supports_switch_configuration + output_mode)
+  - SwitchTypeSelect (switch_type value only — see note below)
+  - ActuatorTypeSelect (actuator_type value only — see note below)
+  - OutputModeSelect (output_mode value only — see note below)
   - SmartSensitivitySecurityLevelSelect (supports_smart_sensitivity + get_smart_sensitivity)
   - SmartSensitivityComfortLevelSelect (supports_smart_sensitivity + get_smart_sensitivity)
+
+Note on SwitchType/ActuatorType/OutputMode: select.py no longer checks
+supports_switch_configuration for these three. That flag only exists on
+SHCMicromoduleRelay (where it's just "the switch-config service is
+present", already implied by switch_type/actuator_type/output_mode being
+non-None); SHCLightControl has no such flag at all, so the old dual guard
+meant Light Control II never got these selects even though the values are
+already null-safe on that class too. Gating on the value alone is correct
+for both device kinds.
 """
 
 from __future__ import annotations
@@ -271,29 +280,27 @@ class TestTerminalTypeSelectGuard:
 
 
 class TestSwitchTypeSelectGuard:
-    def test_supports_false_value_present_skipped(self):
-        relay = _fake_device(switch_type=True,
-                             supports_switch_configuration=False)
+    def test_value_none_skipped(self):
+        relay = _fake_device(switch_type=None)
         entities = _setup(_make_session(micromodule_relays=[relay]))
         assert "SwitchTypeSelect" not in _types(entities)
 
-    def test_supports_true_value_none_skipped(self):
-        relay = _fake_device(switch_type=None,
-                             supports_switch_configuration=True)
-        entities = _setup(_make_session(micromodule_relays=[relay]))
-        assert "SwitchTypeSelect" not in _types(entities)
-
-    def test_both_present_created(self):
-        relay = _fake_device(switch_type=True,
-                             supports_switch_configuration=True)
+    def test_value_present_created(self):
+        relay = _fake_device(switch_type=True)
         entities = _setup(_make_session(micromodule_relays=[relay]))
         assert "SwitchTypeSelect" in _types(entities)
 
     def test_light_control_value_none_skipped(self):
-        lc = _fake_device(switch_type=None,
-                          supports_switch_configuration=True)
+        lc = _fake_device(switch_type=None)
         entities = _setup(_make_session(micromodule_light_controls=[lc]))
         assert "SwitchTypeSelect" not in _types(entities)
+
+    def test_light_control_value_present_created(self):
+        """Regression test: LightControl has no supports_switch_configuration
+        at all, so this must be gated on switch_type alone, not that flag."""
+        lc = _fake_device(switch_type=True)
+        entities = _setup(_make_session(micromodule_light_controls=[lc]))
+        assert "SwitchTypeSelect" in _types(entities)
 
 
 # ---------------------------------------------------------------------------
@@ -302,22 +309,26 @@ class TestSwitchTypeSelectGuard:
 
 
 class TestActuatorTypeSelectGuard:
-    def test_supports_false_value_present_skipped(self):
-        relay = _fake_device(actuator_type=True,
-                             supports_switch_configuration=False)
+    def test_value_none_skipped(self):
+        relay = _fake_device(actuator_type=None)
         entities = _setup(_make_session(micromodule_relays=[relay]))
         assert "ActuatorTypeSelect" not in _types(entities)
 
-    def test_supports_true_value_none_skipped(self):
-        relay = _fake_device(actuator_type=None,
-                             supports_switch_configuration=True)
+    def test_value_present_created(self):
+        relay = _fake_device(actuator_type=True)
         entities = _setup(_make_session(micromodule_relays=[relay]))
+        assert "ActuatorTypeSelect" in _types(entities)
+
+    def test_light_control_value_none_skipped(self):
+        lc = _fake_device(actuator_type=None)
+        entities = _setup(_make_session(micromodule_light_controls=[lc]))
         assert "ActuatorTypeSelect" not in _types(entities)
 
-    def test_both_present_created(self):
-        relay = _fake_device(actuator_type=True,
-                             supports_switch_configuration=True)
-        entities = _setup(_make_session(micromodule_relays=[relay]))
+    def test_light_control_value_present_created(self):
+        """Regression test: LightControl has no supports_switch_configuration
+        at all, so this must be gated on actuator_type alone, not that flag."""
+        lc = _fake_device(actuator_type=True)
+        entities = _setup(_make_session(micromodule_light_controls=[lc]))
         assert "ActuatorTypeSelect" in _types(entities)
 
 
@@ -327,22 +338,26 @@ class TestActuatorTypeSelectGuard:
 
 
 class TestOutputModeSelectGuard:
-    def test_supports_false_value_present_skipped(self):
-        relay = _fake_device(output_mode=True,
-                             supports_switch_configuration=False)
+    def test_value_none_skipped(self):
+        relay = _fake_device(output_mode=None)
         entities = _setup(_make_session(micromodule_relays=[relay]))
         assert "OutputModeSelect" not in _types(entities)
 
-    def test_supports_true_value_none_skipped(self):
-        relay = _fake_device(output_mode=None,
-                             supports_switch_configuration=True)
+    def test_value_present_created(self):
+        relay = _fake_device(output_mode=True)
         entities = _setup(_make_session(micromodule_relays=[relay]))
+        assert "OutputModeSelect" in _types(entities)
+
+    def test_light_control_value_none_skipped(self):
+        lc = _fake_device(output_mode=None)
+        entities = _setup(_make_session(micromodule_light_controls=[lc]))
         assert "OutputModeSelect" not in _types(entities)
 
-    def test_both_present_created(self):
-        relay = _fake_device(output_mode=True,
-                             supports_switch_configuration=True)
-        entities = _setup(_make_session(micromodule_relays=[relay]))
+    def test_light_control_value_present_created(self):
+        """Regression test: LightControl has no supports_switch_configuration
+        at all, so this must be gated on output_mode alone, not that flag."""
+        lc = _fake_device(output_mode=True)
+        entities = _setup(_make_session(micromodule_light_controls=[lc]))
         assert "OutputModeSelect" in _types(entities)
 
 


### PR DESCRIPTION
## What

`SwitchTypeSelect`/`ActuatorTypeSelect`/`OutputModeSelect` in `select.py` were gated on `getattr(device, "supports_switch_configuration", False)` **and** the individual value being non-None, for both `micromodule_relays` and `micromodule_light_controls`.

`SHCLightControl` (backing `micromodule_light_controls`) has no `supports_switch_configuration` property at all in `boschshcpy` — only `SHCMicromoduleRelay` does. So `getattr(..., False)` always returned `False` for every Light Control II device, and it silently got **zero** of these three selects, even though `switch_type`/`actuator_type`/`output_mode` are real, null-safe properties on `SHCLightControl` too (same "return `None` if the underlying service is absent" pattern as on `SHCMicromoduleRelay`).

## Why it's safe

On `SHCMicromoduleRelay` itself, `supports_switch_configuration` is literally `self._switch_config_service is not None` — the exact same condition the three value properties already check internally. So the flag was a redundant tautology there too; removing it changes nothing for relays and only unblocks Light Control II.

## How this was found

Found while porting the equivalent `select` platform to home-assistant/core (tschamm/boschshc-hass upstream contribution work) — that port had the identical bug pattern (for a different underlying reason: no `supports_` flag existed there either). Verified independently against `boschshcpy` 0.4.6's actual class hierarchy, and confirmed safe by two independent adversarial review passes before opening this PR (each was asked to actively try to find a reason the fix is wrong; neither did — see full findings in the session notes, happy to share).

## Tests

Reworked `test_apk_dual_guard_select.py`: removed 3 cases that exercised an artificial `supports_switch_configuration=False` + `value=True` device state that's impossible on real hardware (both derived from the same service reference), added matching Light Control II value-none/value-present cases for all three selects (previously only `SwitchType` had that coverage). Local gate green (ruff, pylint, quality-scale, translations, full test suite).

Not tied to a reported issue — found via code review, not a user report. Queuing for the next release batch, not requesting an immediate release.